### PR TITLE
fix: Invert the default orientation of Chevron icon for tasks

### DIFF
--- a/web/index.html.original
+++ b/web/index.html.original
@@ -34372,7 +34372,7 @@
                             
                             <div className="flex items-center gap-2">
                                 <span className={`transition-transform ${expanded ? '' : 'rotate-180'}`}>
-                                    <Icons.ChevronUp />
+                                    <Icons.ChevronDown />
                                 </span>
                             </div>
                         </div>


### PR DESCRIPTION
fix: Invert the default orientation of Chevron icon for tasks
  - Show Chevron up when collapsed


### Output with patch
![pegaprox_taks_icon_ivert](https://github.com/user-attachments/assets/66964dc5-abc6-4301-97d1-a9fdf6f71ac5)
