### PR TITLE
fix(deploy): skip interactive port prompt when stdin is not a terminal

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -228,7 +228,8 @@ main() {
     print_step "Step 6/6: Configuring Service"
 
     # Interactive port selection
-    if [ "$INTERACTIVE" = true ]; then
+    # Check stdin is a terminal (not piped), so curl | bash installs don't hang
+    if [ "$INTERACTIVE" = true ] && [ -t 0 ]; then
         echo -e "${YELLOW}Select access port:${NC}"
         echo "  1) Default (5000) - Standard ports"
         echo "  2) HTTPS (443)    - Professional setup"


### PR DESCRIPTION
## Summary

Fixes #54

When running the one-liner install via `curl -sSL ... | sudo bash`, stdin is a pipe rather than a terminal. The `read` call at Step 6/6 waits for input that never arrives, and with `set -e` in effect the script exits silently — leaving the install incomplete.

- Add `&& [ -t 0 ]` to the `INTERACTIVE` check so the port-selection prompt is only shown when a real TTY is attached
- Non-interactive / piped installs fall through cleanly and use the default `ACCESS_PORT` (5000)

This is exactly the fix confirmed by the original reporter in the issue.

## Test plan

- [ ] Run `curl -sSL <install-url> | sudo bash` — install should complete through Step 6/6 without hanging
- [ ] Run `sudo ./deploy.sh` directly in a terminal — interactive port prompt should still appear
- [ ] Run `sudo ./deploy.sh --no-interactive` — should skip prompt as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)