### PR TITLE
fix(a11y): set <html lang="en"> — was incorrectly set to "de"

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -71,7 +71,7 @@
     
     ═══════════════════════════════════════════════════════════════
 -->
-<html lang="de">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary

The document `lang` attribute was hardcoded as German (`lang="de"`) even though the app defaults to English and all static markup is in English.

Screen readers, browser translation prompts, and search engine crawlers all use the `lang` attribute to determine the page language. With `lang="de"` set, German-speaking users would get no browser translation offer (since the browser thinks it's already in their language), and English screen readers would use incorrect pronunciation rules.

The runtime language selection is already handled by `LanguageContext` / `localStorage` — this attribute only needs to reflect the document's default language.

## Test plan
- [ ] Load the page and inspect the `<html>` element — should show `lang="en"`
- [ ] Verify browser translation offer appears for non-English browser users
- [ ] Verify runtime language switching (EN/DE) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)