### PR TITLE
fix(update): restore 0700 permissions on config/ and ssl/ after update

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -167,6 +167,19 @@ if [ "$EUID" -eq 0 ] && [ -n "$ORIGINAL_OWNER" ] && [ "$ORIGINAL_OWNER" != "root
     echo -e "${GREEN}OK${NC}"
 fi
 
+# Restore restrictive permissions on config and ssl directories.
+# These must be 0700 so that only the service user can read the encrypted
+# database and SSL private keys. An update that runs as root via sudo can
+# inadvertently leave them world-readable if umask is permissive.
+if [ -d "config" ]; then
+    chmod 700 config 2>/dev/null || true
+fi
+if [ -d "config/ssl" ]; then
+    chmod 700 config/ssl 2>/dev/null || true
+elif [ -d "ssl" ]; then
+    chmod 700 ssl 2>/dev/null || true
+fi
+
 # Install/update Python packages
 echo ""
 echo -n "Installing Python packages... "


### PR DESCRIPTION
## Summary

When `update.sh` runs as root (the typical `sudo ./update.sh` flow), the shell's umask can leave `config/` and `config/ssl/` with overly permissive modes after the git pull + file ownership restore step.

These directories hold the encrypted SQLite database (`pegaprox.db`) and SSL private keys — they should only be readable by the service user (mode `0700`).

**Change:** Add an explicit `chmod 700` for `config/`, `config/ssl/`, and the legacy `ssl/` location at the end of the ownership-fix block, so permissions are always correct regardless of the caller's umask.

## Test plan
- [ ] Run `sudo ./update.sh` and verify `config/` has permissions `drwx------` after completion
- [ ] Verify `config/ssl/` (or `ssl/`) also has `drwx------`
- [ ] Confirm PegaProx service starts normally after the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)