### PR TITLE
fix(deploy): warn on privileged custom port and strip leading zeros

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -248,11 +248,19 @@ main() {
                     ;;
                 3)
                     read -p "Enter port (1-65535): " CUSTOM_PORT
+                    # Strip leading zeros so bash arithmetic doesn't treat value as octal
+                    CUSTOM_PORT="${CUSTOM_PORT##+(0)}"
+                    CUSTOM_PORT="${CUSTOM_PORT:-0}"
                     if [[ "$CUSTOM_PORT" =~ ^[0-9]+$ ]] && [ "$CUSTOM_PORT" -ge 1 ] && [ "$CUSTOM_PORT" -le 65535 ]; then
                         ACCESS_PORT=$CUSTOM_PORT
+                        if [ "$ACCESS_PORT" -lt 1024 ]; then
+                            echo -e "${YELLOW}  ⚠ Port $ACCESS_PORT is privileged (<1024).${NC}"
+                            echo -e "${YELLOW}    The service will use CAP_NET_BIND_SERVICE to bind it.${NC}"
+                            echo -e "${YELLOW}    Ensure the host grants this capability or run as root.${NC}"
+                        fi
                         break
                     else
-                        echo -e "${RED}Invalid port${NC}"
+                        echo -e "${RED}Invalid port. Please enter a number between 1 and 65535.${NC}"
                     fi
                     ;;
                 *)


### PR DESCRIPTION
## Summary

Two issues with the custom port input (option 3) in the interactive port-selection step of `deploy.sh`:

1. **Leading zeros** — bash integer comparisons interpret values like `"007"` as octal in some shells. Strip leading zeros with parameter expansion before the range check.

2. **No inline warning for privileged ports** — entering a port below 1024 silently succeeded; the only hint was a brief note printed _after_ the loop. Now, when a privileged port is chosen via the custom option, an explicit three-line warning is printed immediately so the user can reconsider before installation continues.

## Test plan
- [ ] Enter `007` as a custom port — should be treated as port 7, not octal 7
- [ ] Enter `80` as a custom port — warning about privileged ports should appear before proceeding
- [ ] Enter `8080` — no warning, install proceeds normally
- [ ] Enter `99999` — "Invalid port" error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)