### PR TITLE
Add RPM packaging support for RHEL-based systems

### DIFF
--- a/packaging/rpm/pegaprox.spec
+++ b/packaging/rpm/pegaprox.spec
@@ -1,0 +1,103 @@
+Version:        0.6.6
+Name:		pegaprox
+Release:        1%{?dist}
+Summary:        Multi-cluster Proxmox VE management dashboard
+
+License:        AGPL-3.0-only
+URL:            https://github.com/PegaProx/project-pegaprox
+Source0:        %{name}-%{version}.tar.xz
+
+BuildArch:      noarch
+BuildRequires:  python3-devel
+
+# Runtime dependencies (system python packages)
+Requires:       python3
+Requires:       python3-flask
+Requires:       python3-flask-cors
+Requires:       python3-requests
+Requires:       python3-cryptography
+Requires:       python3-argon2-cffi
+Requires:       python3-pyotp
+Requires:       python3-qrcode
+Requires:       python3-pyOpenSSL
+
+#Custom Build Python Package
+Requires:       python3-backports-zstd
+Requires:       python3-flask-compress
+Requires:       python3-flask-cors
+Requires:       python3-flask-sock
+Requires:       python3-qrcode
+Requires:       python3-simple-websocket
+Requires:       python3-wsproto
+Requires:       python3-pypng
+
+# Optional (if available in EPEL)
+Requires:       python3-gevent
+Requires:       python3-websockets
+Requires:       python3-paramiko
+
+%description
+PegaProx is a web-based multi-cluster management interface for
+Proxmox VE clusters. It provides unified dashboards, VM management,
+load balancing, migration features, and role-based access control.
+
+%prep
+%autosetup
+
+%build
+# Nothing to compile
+true
+
+%install
+rm -rf %{buildroot}
+
+# Application directory
+install -d %{buildroot}%{_libexecdir}/pegaprox
+
+# Copy source files
+cp -a * %{buildroot}%{_libexecdir}/pegaprox/
+
+# Create executable wrapper
+install -d %{buildroot}%{_bindir}
+cat > %{buildroot}%{_bindir}/pegaprox << 'EOF'
+#!/bin/bash
+exec /usr/bin/python3 /usr/libexec/pegaprox/pegaprox_multi_cluster.py "$@"
+EOF
+chmod 0755 %{buildroot}%{_bindir}/pegaprox
+
+# Systemd service
+install -d %{buildroot}%{_unitdir}
+cat > %{buildroot}%{_unitdir}/pegaprox.service << 'EOF'
+[Unit]
+Description=PegaProx Multi-Cluster Management Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /usr/libexec/pegaprox/pegaprox_multi_cluster.py
+WorkingDirectory=/usr/libexec/pegaprox
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+%files
+%license LICENSE
+%doc README.md
+%{_libexecdir}/pegaprox
+%{_bindir}/pegaprox
+%{_unitdir}/pegaprox.service
+
+%post
+%systemd_post pegaprox.service
+
+%preun
+%systemd_preun pegaprox.service
+
+%postun
+%systemd_postun_with_restart pegaprox.service
+
+%changelog
+* Mon Feb 23 2026 Zakir Hossain <zakirpcs@gmail.com> - 0.6.6-1
+- Initial RPM build for RHEL 9


### PR DESCRIPTION
**Summary**

This PR introduces native RPM packaging support for project-pegaprox, enabling installation on RHEL-based distributions such as:

1. Red Hat Enterprise Linux 9
2. AlmaLinux 9
3. Rocky Linux 9

The goal is to simplify deployment in enterprise environments where RPM-based lifecycle management is standard.

**Changes Included**

Added RPM spec file under packaging/rpm/

Defined proper:
BuildRequires
Runtime dependencies
File manifest
Integrated systemd unit file
Verified successful build using rpmbuild on AlmaLinux 9
Clean build with no unpackaged file errors

Build Instructions
To build the RPM:

```
dnf install rpm-build rpmdevtools
rpmdev-setuptree
cp packaging/rpm/pegaprox.spec ~/rpmbuild/SPECS/
cp <generated-source-tarball> ~/rpmbuild/SOURCES/
rpmbuild -ba ~/rpmbuild/SPECS/pegaprox.spec
```

The resulting RPM will be available under:
~/rpmbuild/RPMS/x86_64/

Why This Is Useful
- Many enterprise environments rely on:
- Native RPM lifecycle management
- Centralized repositories (Foreman, Satellite, Spacewalk)
- Patch governance and version control
- Configuration management via Ansible
- Providing an official spec file allows:
- Clean integration into internal repositories
- Automated CI-based RPM builds
- Easier adoption in production infrastructure

**Testing**
Built and tested on AlmaLinux 9

**Verified**:
- Successful installation via dnf install
- Service start/stop behavior via systemd script
- Proper dependency resolution

**Notes**
- No core source code modifications were made.
- This change only introduces packaging support.
- Pre-built RPMs are not included in the repository.