### PR TITLE
fix: Add IPv6 support to pegaprox listener

### DIFF
--- a/pegaprox/app.py
+++ b/pegaprox/app.py
@@ -568,16 +568,20 @@ def main(debug_mode=False):
     # Load server settings
     server_settings = load_server_settings()
     port = server_settings.get('port', 5000)
-    bind_host = os.environ.get('PEGAPROX_HOST', '0.0.0.0')
+    bind_host = os.environ.get('PEGAPROX_HOST')
 
-    # Issue #71 (FireAmpersand): IPv6 support via PEGAPROX_HOST=::
-    if ':' in bind_host and not _test_ipv6_available():
-        print(f"WARNING: IPv6 bind address '{bind_host}' requested but IPv6 not available on this system")
-        print("         Falling back to 0.0.0.0 (IPv4 only)")
-        bind_host = '0.0.0.0'
-
-    if ':' in bind_host:
-        print(f"Binding to {bind_host} (dual-stack IPv4+IPv6)")
+    if not bind_host:
+        if _test_ipv6_available():
+            bind_host = '::'
+            print("IPv6 available — binding dual-stack (::)")
+        else:
+            bind_host = '0.0.0.0'
+            print("IPv6 not available — binding IPv4 only (0.0.0.0)")
+    else:
+        if ':' in bind_host and not _test_ipv6_available():
+            print(f"WARNING: IPv6 bind address '{bind_host}' requested but IPv6 not available")
+            print("Falling back to 0.0.0.0")
+            bind_host = '0.0.0.0'
 
     ssl_enabled = server_settings.get('ssl_enabled', False)
     domain = server_settings.get('domain', '')


### PR DESCRIPTION
fix: Add IPv6 support to pegaprox listener

Summary:
Currently, IPv6 support only works when an IPv6 address is given via `PEGAPROX_HOST` ENV. If this is not set, it directly defaults to `0.0.0.0`.  Further IPv6 "validation" is only performed, when a `:` is given within a string.  Therefore, we do not provide a default for the bind_host an evaluate the possible listeners. However, a user can still provide an explicit listener of ipv4 or ipv6.

Fixes: #71