### PR TITLE
Fix CSRF origin validation failing behind reverse proxy

### DIFF
--- a/pegaprox/app.py
+++ b/pegaprox/app.py
@@ -151,9 +151,10 @@ def create_app():
                 # form uploads must have X-Requested-With or matching Origin
                 has_xhr = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
                 origin = request.headers.get('Origin', '')
+                allowed_origins = get_allowed_origins() or []
                 has_valid_origin = origin and (
-                    origin.startswith(f"{request.scheme}://{request.host}") or
-                    not origin  # same-origin requests may omit Origin
+                    origin in allowed_origins or
+                    origin.startswith(f"{request.scheme}://{request.host}")
                 )
                 if not has_xhr and not has_valid_origin:
                     return jsonify({'error': 'CSRF validation failed'}), 403


### PR DESCRIPTION
## Problem

The CSRF check for multipart form uploads (added in #118) validates the request `Origin` header by comparing it against `request.scheme://request.host`. Behind a reverse proxy, these values reflect the **internal** connection (e.g., `http://127.0.0.1:5000`) rather than the public-facing URL the browser actually used. This causes legitimate multipart upload requests from configured allowed origins to be rejected with a `403 CSRF validation failed` error.

The dead branch `not origin` was also unreachable — the outer `origin and (...)` already guarantees `origin` is truthy inside the parens.

## Fix

Check the `Origin` header against the configured `allowed_origins` list (from the existing `get_allowed_origins()` helper) as the primary match, keeping the `scheme://host` comparison as a fallback for direct-access (non-proxied) deployments.

```python
# Before
has_valid_origin = origin and (
    origin.startswith(f"{request.scheme}://{request.host}") or
    not origin  # same-origin requests may omit Origin
)

# After
allowed_origins = get_allowed_origins() or []
has_valid_origin = origin and (
    origin in allowed_origins or
    origin.startswith(f"{request.scheme}://{request.host}")
)
```

## Impact

- Deployments behind a reverse proxy with configured `ALLOWED_ORIGINS` will now correctly accept multipart uploads from those origins.
- Direct-access deployments are unaffected — the `scheme://host` fallback still applies.
- No new dependencies or config keys introduced.