### PR TITLE
Add Login Background To Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ logs/
 backups/
 *.db
 *.db-journal
+images/login_bg.png
 
 # Build artifacts
 web/Dev/.build/
@@ -30,3 +31,4 @@ archive/
 .idea/
 *.swp
 *.swo
+


### PR DESCRIPTION
## Summary

Adds `images/login_bg.png` to `.gitignore` to prevent user-specific login background images from being tracked in version control. This ensures that personal customization set through the UI does not appear as uncommitted changes or get accidentally committed.

## What changed

**Repository (`.gitignore`)**

Added the following line:

```
images/login_bg.png
```

The login background image is user-defined via settings and stored locally. Since this file varies per user and environment, it should not be tracked by Git.

## Behaviour

* Setting a custom login background no longer shows up as a modified file in Git
* Prevents accidental commits of user-specific assets
* Keeps the repository clean and consistent across different environments
* No impact on application functionality — only affects version control behavior

## Screenshots

### Git status

#### Before

```
modified:   images/login_bg.png
```

#### After

```
(no changes related to login_bg.png)
```
