### PR TITLE
update http2 directive to new format

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -31,7 +31,7 @@ server {
 }
 
 server {
-    listen 443 ssl
+    listen 443 ssl;
     http2 on;
     server_name pegaprox.example.com;
 


### PR DESCRIPTION
https://hg.nginx.org/nginx/rev/08ef02ad5c54

removes the following warning
```
2026/03/26 09:39:23 [warn] 1175798#1175798: the "listen ... http2" directive is deprecated, use the "http2" directive instead in /path/to/vhost
``` 