### PR TITLE
fix: Allow email addresses as valid users

### DIFF
--- a/pegaprox/api/auth.py
+++ b/pegaprox/api/auth.py
@@ -30,10 +30,11 @@ from pegaprox.utils.oidc import (
     get_oidc_settings, get_oidc_endpoints, oidc_build_auth_url,
     oidc_exchange_code, oidc_decode_id_token, oidc_get_user_info,
     oidc_get_user_groups, oidc_map_groups_to_role, oidc_provision_user,
+    get_oidc_username,
 )
 from pegaprox.utils.rbac import get_user_permissions, DEFAULT_TENANT_ID
 from pegaprox.api.helpers import load_server_settings, save_server_settings, get_login_settings, get_session_timeout, safe_error
-from pegaprox.utils.sanitization import sanitize_identifier
+from pegaprox.utils.sanitization import sanitize_identifier, sanitize_username, validate_email
 from pegaprox.utils.ssh import check_auth_action_rate_limit
 # NS: Mar 2026 - removed add_allowed_origin import (no longer auto-adding on login)
 import requests
@@ -183,12 +184,7 @@ def oidc_callback():
         # Check if user already exists
         # MK: this has to match the logic in oidc_provision_user or we get mismatches
         # (had a bug where "john.doe" here vs "johndoe" in provision caused 403s)
-        email = user_info.get('email') or user_info.get('preferred_username', '')
-        raw_username = user_info.get('preferred_username') or email
-        check_username = raw_username.split('@')[0].lower() if '@' in raw_username else raw_username.lower()
-        check_username = ''.join(c for c in check_username if c.isalnum() or c in '._-')
-        if not check_username:
-            check_username = f"oidc_{user_info.get('sub', 'unknown')[:12]}"
+        check_username = get_oidc_username(user_info)
         users = load_users()
         if check_username not in users:
             return jsonify({'error': 'User account does not exist. Contact an administrator.'}), 403
@@ -354,8 +350,9 @@ def auth_login():
     if not data:
         return jsonify({'error': 'Invalid request body'}), 400
     
-    # sanitize inputs (security stuff)
-    username = sanitize_identifier(data.get('username', '').strip().lower(), max_length=64)
+    input_username = data.get('username', '')
+    normalized_username = input_username.strip().lower()
+    username = sanitize_username(normalized_username, max_length=64)
     password = data.get('password', '')[:256]  # limit to prevent DoS
     totp_code = sanitize_identifier(data.get('totp_code', ''), max_length=10)
     
@@ -363,6 +360,12 @@ def auth_login():
     
     if not username or not password:
         return jsonify({'error': 'Username and password required'}), 400
+
+    if username != normalized_username:
+        return jsonify({'error': 'Username contains invalid characters'}), 400
+
+    if '@' in username and not validate_email(username):
+        return jsonify({'error': 'Username must be a valid email address'}), 400
     
     if len(username) < 2:
         return jsonify({'error': 'Username too short'}), 400

--- a/pegaprox/api/users.py
+++ b/pegaprox/api/users.py
@@ -30,6 +30,7 @@ from pegaprox.utils.rbac import (
     DEFAULT_TENANT_ID, ROLE_TEMPLATES,
 )
 from pegaprox.api.helpers import load_server_settings, save_server_settings, get_login_settings, check_cluster_access, safe_error
+from pegaprox.utils.sanitization import sanitize_username, validate_email
 
 bp = Blueprint('users', __name__)
 
@@ -568,7 +569,9 @@ def create_user():
     global users_db
     
     data = request.get_json()
-    username = data.get('username', '').strip().lower()
+    input_username = data.get('username', '')
+    raw_username = input_username.strip().lower()
+    username = sanitize_username(raw_username, max_length=64)
     password = data.get('password', '')
     role = data.get('role', ROLE_USER)
     display_name = data.get('display_name', username)
@@ -579,6 +582,12 @@ def create_user():
     
     if not username or not password:
         return jsonify({'error': 'Username and password required'}), 400
+
+    if username != raw_username:
+        return jsonify({'error': 'Username contains invalid characters'}), 400
+
+    if '@' in username and not validate_email(username):
+        return jsonify({'error': 'Username must be a valid email address'}), 400
     
     if len(username) < 3:
         return jsonify({'error': 'Username must be at least 3 characters'}), 400
@@ -1624,4 +1633,3 @@ def rm_pool(cluster_id, pool_id):
     except:
         pass  # NS: not critical, orphaned perms don't hurt
     return jsonify({'success': True})
-

--- a/pegaprox/utils/oidc.py
+++ b/pegaprox/utils/oidc.py
@@ -25,6 +25,7 @@ except ImportError:
 from pegaprox.core.db import get_db
 from pegaprox.globals import users_db
 from pegaprox.models.permissions import ROLE_VIEWER, ROLE_ADMIN, ROLE_USER
+from pegaprox.utils.sanitization import sanitize_username
 
 # ============================================================================
 
@@ -51,6 +52,18 @@ ENTRA_CLOUD_ENDPOINTS = {
         'graph_base': 'dod-graph.microsoft.us',
     },
 }
+
+
+def get_oidc_username(user_info: dict) -> str:
+    """Derive the canonical local username for an OIDC user."""
+    email = user_info.get('email') or user_info.get('preferred_username', '')
+    raw_username = (user_info.get('preferred_username') or email or '').strip().lower()
+    username = sanitize_username(raw_username, max_length=64)
+
+    if not username:
+        username = sanitize_username(f"oidc_{user_info.get('sub', 'unknown')[:12]}", max_length=64)
+
+    return username
 
 def get_oidc_settings() -> dict:
     """Load OIDC/Entra ID configuration from server settings
@@ -467,20 +480,8 @@ def oidc_provision_user(user_info: dict, role_mapping: dict, auth_source: str = 
     NS: JIT provisioning - same pattern as LDAP but for OIDC providers
     MK: username derived from email or preferred_username
     """
-    # Derive username from OIDC claims
     email = user_info.get('email') or user_info.get('preferred_username', '')
-    raw_username = user_info.get('preferred_username') or email
-    
-    # LW: Sanitize username - use part before @ for email-style usernames
-    if '@' in raw_username:
-        username = raw_username.split('@')[0].lower()
-    else:
-        username = raw_username.lower()
-    
-    # NS: Ensure we have a valid username
-    username = ''.join(c for c in username if c.isalnum() or c in '._-')
-    if not username:
-        username = f"oidc_{user_info.get('sub', 'unknown')[:12]}"
+    username = get_oidc_username(user_info)
     
     display_name = user_info.get('name') or user_info.get('given_name', '') 
     if not display_name:

--- a/pegaprox/utils/sanitization.py
+++ b/pegaprox/utils/sanitization.py
@@ -39,6 +39,16 @@ def sanitize_identifier(value: str, max_length: int = 64) -> str:
     return value[:max_length]
 
 
+def sanitize_username(value: str, max_length: int = 64) -> str:
+    """sanitize usernames while preserving common email-local-part characters"""
+    if not isinstance(value, str):
+        value = str(value) if value is not None else ''
+
+    value = re.sub(r'[^a-zA-Z0-9_@.+%-]', '', value)
+
+    return value[:max_length]
+
+
 def sanitize_int(value, default: int = 0, min_val: int = None, max_val: int = None) -> int:
     """Sanitize an integer input"""
     try:
@@ -80,5 +90,3 @@ def validate_hostname(hostname: str) -> bool:
     ip_pattern = r'^(\d{1,3}\.){3}\d{1,3}$'
     hostname_pattern = r'^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$'
     return bool(re.match(ip_pattern, hostname) or re.match(hostname_pattern, hostname))
-
-


### PR DESCRIPTION
fix: Allow email addresses as valid users
 * Adding new username sanitizer allow "@" char

Example:
![pegaprox_email_user](https://github.com/user-attachments/assets/85b9b093-376c-4e38-97c2-f507a697fc2c)


Fixes: #228