### PR TITLE
fix: use SSH-reachable management IP for all node SSH operations

### DIFF
--- a/pegaprox/api/.ssh_ws_server.py
+++ b/pegaprox/api/.ssh_ws_server.py
@@ -102,8 +102,8 @@ async def ssh_handler(websocket):
     # Always fetch cluster creds to get ssh_port; also resolve node_ip
     # if it was not pre-fetched by the frontend.
     try:
-        print(f"Fetching cluster creds from: {PEGAPROX_URL}/api/internal/cluster-creds/{cluster_id}")
-        r = requests.get(f"{PEGAPROX_URL}/api/internal/cluster-creds/{cluster_id}", cookies={'session': session_id}, timeout=10, verify=False)
+        print(f"Fetching cluster creds from: {PEGAPROX_URL}/api/internal/cluster-creds/{cluster_id}?node={node}")
+        r = requests.get(f"{PEGAPROX_URL}/api/internal/cluster-creds/{cluster_id}", params={'node': node}, cookies={'session': session_id}, timeout=10, verify=False)
         print(f"Cluster creds response: {r.status_code}")
         if r.status_code == 200:
             creds = r.json()

--- a/pegaprox/api/.ssh_ws_server.py
+++ b/pegaprox/api/.ssh_ws_server.py
@@ -97,28 +97,28 @@ async def ssh_handler(websocket):
     # Get node IP - use pre-fetched IP if available
     node_ip = prefetched_ip if prefetched_ip else None
     cluster_host = None
-    
-    # Only try API if we don't have a pre-fetched IP
-    if not node_ip:
-        # Method 1: Try API endpoint
-        try:
-            print(f"Fetching cluster creds from: {PEGAPROX_URL}/api/internal/cluster-creds/{cluster_id}")
-            r = requests.get(f"{PEGAPROX_URL}/api/internal/cluster-creds/{cluster_id}", cookies={'session': session_id}, timeout=10, verify=False)
-            print(f"Cluster creds response: {r.status_code}")
-            if r.status_code == 200:
-                creds = r.json()
-                cluster_host = creds.get('host')
+    ssh_port = 22
+
+    # Always fetch cluster creds to get ssh_port; also resolve node_ip
+    # if it was not pre-fetched by the frontend.
+    try:
+        print(f"Fetching cluster creds from: {PEGAPROX_URL}/api/internal/cluster-creds/{cluster_id}")
+        r = requests.get(f"{PEGAPROX_URL}/api/internal/cluster-creds/{cluster_id}", cookies={'session': session_id}, timeout=10, verify=False)
+        print(f"Cluster creds response: {r.status_code}")
+        if r.status_code == 200:
+            creds = r.json()
+            cluster_host = creds.get('host')
+            ssh_port = creds.get('ssh_port', 22) or 22
+            if not node_ip:
                 node_ips = creds.get('node_ips', {})
-                
-                # Try exact match first, then case-insensitive
                 node_ip = node_ips.get(node) or node_ips.get(node.lower())
-                
                 print(f"Got node_ips: {node_ips}, looking for: {node}, found: {node_ip}, cluster_host: {cluster_host}")
-            else:
-                print(f"Cluster creds failed: {r.status_code} - {r.text[:200] if r.text else 'no body'}")
-        except Exception as e:
-            print(f"Could not get node IP from API: {e}")
-        
+        else:
+            print(f"Cluster creds failed: {r.status_code} - {r.text[:200] if r.text else 'no body'}")
+    except Exception as e:
+        print(f"Could not get cluster creds from API: {e}")
+
+    if not node_ip:
         # Method 2: Fallback - read directly from clusters config file
         if not cluster_host:
             try:
@@ -147,9 +147,9 @@ async def ssh_handler(websocket):
                             print(f"Cluster {cluster_id} not in config, available: {list(clusters.keys())}")
             except Exception as e:
                 print(f"Config file fallback failed: {e}")
-        
+
         # Use cluster_host as fallback for node_ip
-        if not node_ip and cluster_host:
+        if cluster_host:
             node_ip = cluster_host
             print(f"Using cluster host as fallback: {cluster_host}")
     
@@ -232,17 +232,17 @@ async def ssh_handler(websocket):
                 
                 if pkey:
                     print(f"Using SSH key authentication")
-                    ssh.connect(node_ip, port=22, username=ssh_user, pkey=pkey, timeout=10, look_for_keys=False, allow_agent=False)
+                    ssh.connect(node_ip, port=ssh_port, username=ssh_user, pkey=pkey, timeout=10, look_for_keys=False, allow_agent=False)
                 else:
                     raise Exception("Could not parse SSH key - unsupported format")
-                    
+
             except Exception as key_error:
                 print(f"SSH key auth failed: {key_error}")
                 await websocket.send(f'{{"status":"error","message":"SSH key error: {str(key_error)}"}}')
                 return
         else:
             # Password authentication
-            ssh.connect(node_ip, port=22, username=ssh_user, password=ssh_pass, timeout=10, look_for_keys=False, allow_agent=False)
+            ssh.connect(node_ip, port=ssh_port, username=ssh_user, password=ssh_pass, timeout=10, look_for_keys=False, allow_agent=False)
         
         channel = ssh.invoke_shell(term='xterm-256color', width=120, height=40)
         channel.settimeout(0.1)

--- a/pegaprox/api/auth.py
+++ b/pegaprox/api/auth.py
@@ -891,26 +891,21 @@ def get_cluster_creds_internal(cluster_id):
             node_ips['_default'] = cluster_host
     else:
         try:
-            host = cluster_host
-
-            # Method 1: Get from Proxmox cluster status API (has IPs for clustered nodes)
-            status_url = f"https://{host}:8006/api2/json/cluster/status"
-            r = mgr._create_session().get(status_url, timeout=10)
-
-            if r.status_code == 200:
-                status_data = r.json().get('data', [])
-                logging.info(f"[CLUSTER-CREDS] Cluster status returned {len(status_data)} items")
-                for item in status_data:
-                    if item.get('type') == 'node':
-                        node_name = item.get('name', '')
-                        node_ip = item.get('ip')
-                        logging.info(f"[CLUSTER-CREDS] Cluster status node: {node_name}, ip={node_ip}")
-                        if node_name and node_ip:
-                            # Store with original case and lowercase for matching
-                            node_ips[node_name] = node_ip
-                            node_ips[node_name.lower()] = node_ip
-
-
+            # Use _get_node_ip per node: filters Corosync IPs, probes SSH port.
+            # cluster/status returns the Corosync ring IP which is not
+            # necessarily reachable via SSH from the PegaProx server.
+            nodes = mgr.get_nodes() or []
+            for n in nodes:
+                node_name = n.get('node', n.get('name', ''))
+                if not node_name:
+                    continue
+                node_ip = mgr._get_node_ip(node_name)
+                if node_ip:
+                    node_ips[node_name] = node_ip
+                    node_ips[node_name.lower()] = node_ip
+                    logging.info(f"[CLUSTER-CREDS] node {node_name} ip={node_ip}")
+                else:
+                    logging.warning(f"[CLUSTER-CREDS] _get_node_ip returned nothing for {node_name}")
         except Exception as e:
             logging.error(f"[CLUSTER-CREDS] Error getting node IPs: {e}")
 

--- a/pegaprox/api/auth.py
+++ b/pegaprox/api/auth.py
@@ -894,8 +894,15 @@ def get_cluster_creds_internal(cluster_id):
             # Use _get_node_ip per node: filters Corosync IPs, probes SSH port.
             # cluster/status returns the Corosync ring IP which is not
             # necessarily reachable via SSH from the PegaProx server.
-            nodes = mgr.get_nodes() or []
-            for n in nodes:
+            # Use _cached_nodes if available (populated by get_cluster_nodes()),
+            # otherwise fall back to the same REST call as get_cluster_nodes().
+            nodes = getattr(mgr, '_cached_nodes', None)
+            if not nodes:
+                r = mgr._create_session().get(f"https://{cluster_host}:8006/api2/json/nodes", timeout=10)
+                if r.status_code == 200:
+                    nodes = r.json().get('data', [])
+                    mgr._cached_nodes = nodes
+            for n in (nodes or []):
                 node_name = n.get('node', n.get('name', ''))
                 if not node_name:
                     continue

--- a/pegaprox/api/auth.py
+++ b/pegaprox/api/auth.py
@@ -923,9 +923,11 @@ def get_cluster_creds_internal(cluster_id):
     
     # NS Feb 2026: Never expose Proxmox password via API - shell proxy handles auth server-side
     # NS Mar 2026: removed user field from response, only SSH proxy needs it internally
+    ssh_port = getattr(mgr.config, 'ssh_port', 22) or 22
     return jsonify({
         'host': cluster_host,
-        'node_ips': node_ips
+        'node_ips': node_ips,
+        'ssh_port': ssh_port
     })
 
 

--- a/pegaprox/api/auth.py
+++ b/pegaprox/api/auth.py
@@ -890,29 +890,37 @@ def get_cluster_creds_internal(cluster_id):
         if not node_ips:
             node_ips['_default'] = cluster_host
     else:
+        # ?node=<name>: resolve only the requested node (used by WS server to
+        # avoid probing every node in the cluster on each shell open).
+        requested_node = request.args.get('node', '').strip()
+
+        def _resolve_node(node_name):
+            node_ip = mgr._get_node_ip(node_name)
+            if node_ip:
+                node_ips[node_name] = node_ip
+                node_ips[node_name.lower()] = node_ip
+                logging.info(f"[CLUSTER-CREDS] node {node_name} ip={node_ip}")
+            else:
+                logging.warning(f"[CLUSTER-CREDS] _get_node_ip returned nothing for {node_name}")
+
         try:
-            # Use _get_node_ip per node: filters Corosync IPs, probes SSH port.
-            # cluster/status returns the Corosync ring IP which is not
-            # necessarily reachable via SSH from the PegaProx server.
-            # Use _cached_nodes if available (populated by get_cluster_nodes()),
-            # otherwise fall back to the same REST call as get_cluster_nodes().
-            nodes = getattr(mgr, '_cached_nodes', None)
-            if not nodes:
-                r = mgr._create_session().get(f"https://{cluster_host}:8006/api2/json/nodes", timeout=10)
-                if r.status_code == 200:
-                    nodes = r.json().get('data', [])
-                    mgr._cached_nodes = nodes
-            for n in (nodes or []):
-                node_name = n.get('node', n.get('name', ''))
-                if not node_name:
-                    continue
-                node_ip = mgr._get_node_ip(node_name)
-                if node_ip:
-                    node_ips[node_name] = node_ip
-                    node_ips[node_name.lower()] = node_ip
-                    logging.info(f"[CLUSTER-CREDS] node {node_name} ip={node_ip}")
-                else:
-                    logging.warning(f"[CLUSTER-CREDS] _get_node_ip returned nothing for {node_name}")
+            if requested_node:
+                # Single-node path: fast, avoids probing unrelated nodes.
+                _resolve_node(requested_node)
+            else:
+                # Bulk path: resolve all nodes (kept for UIs that need full mapping).
+                # Use _cached_nodes if available (populated by get_cluster_nodes()),
+                # otherwise fall back to the same REST call as get_cluster_nodes().
+                nodes = getattr(mgr, '_cached_nodes', None)
+                if not nodes:
+                    r = mgr._create_session().get(f"https://{cluster_host}:8006/api2/json/nodes", timeout=10)
+                    if r.status_code == 200:
+                        nodes = r.json().get('data', [])
+                        mgr._cached_nodes = nodes
+                for n in (nodes or []):
+                    node_name = n.get('node', n.get('name', ''))
+                    if node_name:
+                        _resolve_node(node_name)
         except Exception as e:
             logging.error(f"[CLUSTER-CREDS] Error getting node IPs: {e}")
 

--- a/pegaprox/api/nodes.py
+++ b/pegaprox/api/nodes.py
@@ -70,48 +70,18 @@ def get_node_ip_api(cluster_id, node):
             source = 'xcpng_fallback'
     else:
         try:
-            host = cluster_host
-
-            # Method 1: Cluster status API (has IPs for clustered nodes)
-            status_url = f"https://{host}:8006/api2/json/cluster/status"
-            r = mgr._create_session().get(status_url, timeout=10)
-
-            if r.status_code == 200:
-                for item in r.json().get('data', []):
-                    if item.get('type') == 'node':
-                        item_name = item.get('name', '')
-                        if item_name.lower() == node.lower() and item.get('ip'):
-                            node_ip = item.get('ip')
-                            source = 'cluster_status'
-                            break
-
-            # Method 2: Network configuration API
-            if not node_ip:
-                net_url = f"https://{host}:8006/api2/json/nodes/{node}/network"
-                r = mgr._create_session().get(net_url, timeout=5)
-                if r.status_code == 200:
-                    for iface in r.json().get('data', []):
-                        iface_type = iface.get('type', '')
-                        addr = iface.get('address', '')
-                        cidr = iface.get('cidr', '')
-
-                        if not addr and cidr:
-                            addr = cidr.split('/')[0]
-
-                        if addr and iface_type in ['bridge', 'eth', 'bond', 'OVSBridge', 'vlan']:
-                            node_ip = addr
-                            source = f'network_{iface.get("iface", "unknown")}'
-                            break
-
-            # Method 3: Fallback to cluster host
-            if not node_ip:
-                node_ip = cluster_host
-                source = 'cluster_host_fallback'
-
+            # Use _get_node_ip: scores interfaces, filters Corosync IPs out of
+            # management network, and probes SSH port for reachability.
+            node_ip = mgr._get_node_ip(node)
+            source = 'manager_get_node_ip'
         except Exception as e:
             logging.error(f"Error getting node IP: {e}")
-            node_ip = cluster_host
+            node_ip = None
             source = 'error_fallback'
+
+        if not node_ip:
+            node_ip = cluster_host
+            source = 'cluster_host_fallback'
 
     return jsonify({
         'ip': node_ip,
@@ -874,23 +844,11 @@ def get_smbios_autoconfig_status(cluster_id, node):
     mgr = cluster_managers[cluster_id]
     
     try:
-        # Get node IP and connect via SSH
-        # For single-node, use cluster host; for multi-node, resolve from cluster status
-        node_ip = mgr.host
-        
-        # Try to get actual node IP from cluster status
-        try:
-            status_url = f"https://{node_ip}:8006/api2/json/cluster/status"
-            r = mgr._create_session().get(status_url, timeout=10)
-            if r.status_code == 200:
-                for item in r.json().get('data', []):
-                    if item.get('type') == 'node' and item.get('name', '').lower() == node.lower():
-                        if item.get('ip'):
-                            node_ip = item.get('ip')
-                            break
-        except:
-            pass
-        
+        # Resolve SSH-reachable management IP via _get_node_ip (scores interfaces,
+        # probes SSH port) -- cluster/status returns Corosync IP which may not
+        # be reachable via SSH from the PegaProx server.
+        node_ip = mgr._get_node_ip(node) or mgr.host
+
         ssh = mgr._ssh_connect(node_ip)
         if not ssh:
             return jsonify({'installed': False, 'running': False, 'error': 'SSH not available - check SSH key in cluster settings'})
@@ -936,24 +894,12 @@ def deploy_smbios_autoconfig(cluster_id, node):
     settings = getattr(mgr.config, 'smbios_autoconfig', None) or {}
     
     try:
-        # Get node IP
-        node_ip = mgr.host
-        try:
-            status_url = f"https://{node_ip}:8006/api2/json/cluster/status"
-            r = mgr._create_session().get(status_url, timeout=10)
-            if r.status_code == 200:
-                for item in r.json().get('data', []):
-                    if item.get('type') == 'node' and item.get('name', '').lower() == node.lower():
-                        if item.get('ip'):
-                            node_ip = item.get('ip')
-                            break
-        except:
-            pass
-        
+        node_ip = mgr._get_node_ip(node) or mgr.host
+
         ssh = mgr._ssh_connect(node_ip)
         if not ssh:
             return jsonify({'error': 'SSH connection failed - check SSH key in cluster settings'}), 500
-        
+
         # Generate script with settings (defense-in-depth: strip quotes/backslashes - NS Feb 2026)
         def _sanitize_smbios(val):
             """Strip characters dangerous in Python string literals as defense-in-depth."""
@@ -1000,24 +946,12 @@ def remove_smbios_autoconfig(cluster_id, node):
     mgr = cluster_managers[cluster_id]
     
     try:
-        # Get node IP
-        node_ip = mgr.host
-        try:
-            status_url = f"https://{node_ip}:8006/api2/json/cluster/status"
-            r = mgr._create_session().get(status_url, timeout=10)
-            if r.status_code == 200:
-                for item in r.json().get('data', []):
-                    if item.get('type') == 'node' and item.get('name', '').lower() == node.lower():
-                        if item.get('ip'):
-                            node_ip = item.get('ip')
-                            break
-        except:
-            pass
-        
+        node_ip = mgr._get_node_ip(node) or mgr.host
+
         ssh = mgr._ssh_connect(node_ip)
         if not ssh:
             return jsonify({'error': 'SSH connection failed - check SSH key in cluster settings'}), 500
-        
+
         # Stop and disable service, remove files
         commands = [
             'systemctl stop pegaprox-smbios-autoconfig 2>/dev/null || true',
@@ -1063,20 +997,8 @@ def control_smbios_autoconfig(cluster_id, node):
     mgr = cluster_managers[cluster_id]
     
     try:
-        # Get node IP
-        node_ip = mgr.host
-        try:
-            status_url = f"https://{node_ip}:8006/api2/json/cluster/status"
-            r = mgr._create_session().get(status_url, timeout=10)
-            if r.status_code == 200:
-                for item in r.json().get('data', []):
-                    if item.get('type') == 'node' and item.get('name', '').lower() == node.lower():
-                        if item.get('ip'):
-                            node_ip = item.get('ip')
-                            break
-        except:
-            pass
-        
+        node_ip = mgr._get_node_ip(node) or mgr.host
+
         ssh = mgr._ssh_connect(node_ip)
         if not ssh:
             return jsonify({'error': 'SSH connection failed'}), 500
@@ -1136,16 +1058,7 @@ def get_smbios_autoconfig_status_all(cluster_id):
         if not node_names:
             return jsonify({'error': 'No nodes available'}), 400
 
-        # #198: bulk-resolve node IPs from cluster/status (same as deploy-all)
         node_ips = {}
-        try:
-            cs_resp = mgr._api_get(f"https://{mgr.host}:8006/api2/json/cluster/status")
-            if cs_resp.status_code == 200:
-                for item in cs_resp.json().get('data', []):
-                    if item.get('type') == 'node':
-                        node_ips[item.get('name', '')] = item.get('ip', '')
-        except:
-            pass
 
         results = {}
 
@@ -1214,7 +1127,6 @@ def deploy_smbios_autoconfig_all(cluster_id):
     
     # Get all nodes in cluster
     nodes = []
-    node_ips = {}
     try:
         cluster_host = mgr.host
         status_url = f"https://{cluster_host}:8006/api2/json/cluster/status"
@@ -1222,20 +1134,17 @@ def deploy_smbios_autoconfig_all(cluster_id):
         if r.status_code == 200:
             for item in r.json().get('data', []):
                 if item.get('type') == 'node':
-                    node_name = item.get('name')
-                    nodes.append(node_name)
-                    node_ips[node_name] = item.get('ip') or cluster_host
+                    nodes.append(item.get('name'))
         else:
             # Single node cluster - just use cluster host
             nodes = [mgr.config.host.split('.')[0]]
-            node_ips[nodes[0]] = cluster_host
     except Exception as e:
         logging.error(f"Error getting cluster nodes: {e}")
         return jsonify({'error': f'Could not get cluster nodes: {e}'}), 500
-    
+
     if not nodes:
         return jsonify({'error': 'No nodes found in cluster'}), 404
-    
+
     results = []
     def _sanitize_smbios_val(val):
         """Strip characters dangerous in Python string literals as defense-in-depth."""
@@ -1248,7 +1157,7 @@ def deploy_smbios_autoconfig_all(cluster_id):
     )
 
     for node in nodes:
-        node_ip = node_ips.get(node, mgr.config.host)
+        node_ip = mgr._get_node_ip(node) or mgr.host
         try:
             # NS: Staggered connections to prevent SSH server overload
             if results:  # Not the first node
@@ -1611,8 +1520,6 @@ def run_custom_script(cluster_id, script_id):
     # Get target nodes
     target_nodes = script['target_nodes']
     nodes_to_run = []
-    node_ips = {}
-    
     try:
         cluster_host = mgr.host
         status_url = f"https://{cluster_host}:8006/api2/json/cluster/status"
@@ -1623,24 +1530,23 @@ def run_custom_script(cluster_id, script_id):
                     node_name = item.get('name')
                     if target_nodes == 'all' or node_name in target_nodes.split(','):
                         nodes_to_run.append(node_name)
-                        node_ips[node_name] = item.get('ip') or cluster_host
     except Exception as e:
         logging.error(f"Error getting cluster nodes: {e}")
         return jsonify({'error': f'Could not get cluster nodes: {e}'}), 500
-    
+
     if not nodes_to_run:
         return jsonify({'error': 'No target nodes found'}), 404
-    
+
     # Log the execution attempt BEFORE running
     log_audit(usr, 'script.execution_started', f"Starting execution of script '{script['name']}' (ID: {script_id}) on {len(nodes_to_run)} nodes: {', '.join(nodes_to_run)}", cluster=cluster_name)
-    
+
     results = []
     script_ext = '.py' if script['type'] == 'python' else '.sh'
     interpreter = 'python3' if script['type'] == 'python' else 'bash'
     all_output = []
-    
+
     for node in nodes_to_run:
-        node_ip = node_ips.get(node, mgr.config.host)
+        node_ip = mgr._get_node_ip(node) or mgr.host
         try:
             ssh = mgr._ssh_connect(node_ip)
             if not ssh:

--- a/pegaprox/api/nodes.py
+++ b/pegaprox/api/nodes.py
@@ -847,7 +847,9 @@ def get_smbios_autoconfig_status(cluster_id, node):
         # Resolve SSH-reachable management IP via _get_node_ip (scores interfaces,
         # probes SSH port) -- cluster/status returns Corosync IP which may not
         # be reachable via SSH from the PegaProx server.
-        node_ip = mgr._get_node_ip(node) or mgr.host
+        node_ip = mgr._get_node_ip(node)
+        if not node_ip:
+            return jsonify({'installed': False, 'running': False, 'error': f'Could not determine SSH-reachable IP for node {node}'})
 
         ssh = mgr._ssh_connect(node_ip)
         if not ssh:
@@ -892,9 +894,11 @@ def deploy_smbios_autoconfig(cluster_id, node):
     
     mgr = cluster_managers[cluster_id]
     settings = getattr(mgr.config, 'smbios_autoconfig', None) or {}
-    
+
     try:
-        node_ip = mgr._get_node_ip(node) or mgr.host
+        node_ip = mgr._get_node_ip(node)
+        if not node_ip:
+            return jsonify({'error': f'Could not determine SSH-reachable IP for node {node}'}), 502
 
         ssh = mgr._ssh_connect(node_ip)
         if not ssh:
@@ -944,9 +948,11 @@ def remove_smbios_autoconfig(cluster_id, node):
         return jsonify({'error': 'Cluster not found'}), 404
     
     mgr = cluster_managers[cluster_id]
-    
+
     try:
-        node_ip = mgr._get_node_ip(node) or mgr.host
+        node_ip = mgr._get_node_ip(node)
+        if not node_ip:
+            return jsonify({'error': f'Could not determine SSH-reachable IP for node {node}'}), 502
 
         ssh = mgr._ssh_connect(node_ip)
         if not ssh:
@@ -995,9 +1001,11 @@ def control_smbios_autoconfig(cluster_id, node):
         return jsonify({'error': 'Invalid action. Use start, stop, restart, or rescan'}), 400
     
     mgr = cluster_managers[cluster_id]
-    
+
     try:
-        node_ip = mgr._get_node_ip(node) or mgr.host
+        node_ip = mgr._get_node_ip(node)
+        if not node_ip:
+            return jsonify({'error': f'Could not determine SSH-reachable IP for node {node}'}), 502
 
         ssh = mgr._ssh_connect(node_ip)
         if not ssh:
@@ -1157,7 +1165,10 @@ def deploy_smbios_autoconfig_all(cluster_id):
     )
 
     for node in nodes:
-        node_ip = mgr._get_node_ip(node) or mgr.host
+        node_ip = mgr._get_node_ip(node)
+        if not node_ip:
+            results.append({'node': node, 'success': False, 'error': 'Could not determine SSH-reachable IP'})
+            continue
         try:
             # NS: Staggered connections to prevent SSH server overload
             if results:  # Not the first node
@@ -1546,7 +1557,11 @@ def run_custom_script(cluster_id, script_id):
     all_output = []
 
     for node in nodes_to_run:
-        node_ip = mgr._get_node_ip(node) or mgr.host
+        node_ip = mgr._get_node_ip(node)
+        if not node_ip:
+            results.append({'node': node, 'success': False, 'error': 'Could not determine SSH-reachable IP', 'output': ''})
+            all_output.append(f"=== {node} ===\nCould not determine SSH-reachable IP\n")
+            continue
         try:
             ssh = mgr._ssh_connect(node_ip)
             if not ssh:

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -6422,44 +6422,27 @@ echo "AGENT_INSTALLED_OK"
                 primary_parsed = ipaddress.ip_address(primary_ip)  # IPv4 or IPv6
             except Exception:
                 primary_parsed = None
-            
-            # ================================================================
-            # STEP 0 (Issue #71): Quick path -- get IP from cluster/status
-            # The Proxmox cluster/status API returns each node's IP directly.
-            # This often works even when the complex interface matching fails
-            # (e.g., different VLANs, IPv6-only, or node offline via API).
-            # ================================================================
-            try:
-                cs_url = f"https://{host}:8006/api2/json/cluster/status"
-                cs_resp = self._api_get(cs_url)
-                if cs_resp.status_code == 200:
-                    for item in cs_resp.json().get('data', []):
-                        if item.get('type') == 'node' and item.get('name') == node_name:
-                            node_direct_ip = item.get('ip', '')
-                            if node_direct_ip and node_direct_ip != primary_ip:
-                                if _quick_probe(node_direct_ip):
-                                    self.logger.info(f"[NodeIP] {node_name} -> {node_direct_ip} (from cluster/status, reachable)")
-                                    return node_direct_ip
-                                else:
-                                    self.logger.debug(f"[NodeIP] {node_name}: cluster/status IP {node_direct_ip} not reachable on 8006, continuing...")
-                            break
-            except Exception as e:
-                self.logger.debug(f"[NodeIP] cluster/status quick path failed: {e}")
+
+            # Use the configured SSH port for reachability probes -- port 8006
+            # (Proxmox API) is open on ALL interfaces including cluster/corosync
+            # network, which makes it useless for finding the SSH-reachable IP.
+            ssh_port = getattr(self.config, 'ssh_port', 22) or 22
             
             # ================================================================
             # STEP 1: Find which interface the PRIMARY node uses for management
             # Query the PRIMARY node, NOT the target -- this was the old bug
+            # Run BEFORE STEP 0 so primary_network is available for filtering.
             # ================================================================
             primary_iface = None        # e.g., 'vmbr0.10' or 'vmbr0'
             primary_network = None      # ipaddress.IPv4Network
             primary_vlan_id = None      # e.g., '10', '510', or None
-            
+
             # Cache per-cluster to avoid repeated API calls
             if not hasattr(self, '_cached_mgmt_iface'):
                 self._cached_mgmt_iface = None
                 self._cached_mgmt_network = None
                 self._cached_mgmt_vlan = None
-            
+
             if self._cached_mgmt_iface:
                 primary_iface = self._cached_mgmt_iface
                 primary_network = self._cached_mgmt_network
@@ -6475,7 +6458,7 @@ echo "AGENT_INSTALLED_OK"
                             if item.get('type') == 'node' and item.get('local', 0) == 1:
                                 current_node_name = item.get('name')
                                 break
-                    
+
                     if not current_node_name:
                         nodes_url = f"https://{host}:8006/api2/json/nodes"
                         nodes_resp = self._api_get(nodes_url)
@@ -6484,7 +6467,7 @@ echo "AGENT_INSTALLED_OK"
                                 if n.get('status') == 'online':
                                     current_node_name = n.get('node')
                                     break
-                    
+
                     if current_node_name:
                         net_url = f"https://{host}:8006/api2/json/nodes/{current_node_name}/network"
                         net_resp = self._api_get(net_url)
@@ -6512,6 +6495,41 @@ echo "AGENT_INSTALLED_OK"
                                     continue
                 except Exception as e:
                     self.logger.debug(f"[NodeIP] Could not detect primary interface: {e}")
+
+            # ================================================================
+            # STEP 0 (Issue #71): Quick path -- get IP from cluster/status
+            # The Proxmox cluster/status API returns each node's IP directly.
+            # This often works even when the complex interface matching fails
+            # (e.g., different VLANs, IPv6-only, or node offline via API).
+            # NOTE: Runs after STEP 1 so we can verify the IP is in the
+            # management network -- cluster/status may return the Corosync
+            # ring IP (dedicated cluster network) which is NOT reachable from
+            # the PegaProx server even though it answers on port 8006.
+            # ================================================================
+            try:
+                cs_url = f"https://{host}:8006/api2/json/cluster/status"
+                cs_resp = self._api_get(cs_url)
+                if cs_resp.status_code == 200:
+                    for item in cs_resp.json().get('data', []):
+                        if item.get('type') == 'node' and item.get('name') == node_name:
+                            node_direct_ip = item.get('ip', '')
+                            if node_direct_ip and node_direct_ip != primary_ip:
+                                in_mgmt_net = True
+                                if primary_network:
+                                    try:
+                                        in_mgmt_net = ipaddress.ip_address(node_direct_ip) in primary_network
+                                    except Exception:
+                                        in_mgmt_net = False
+                                if not in_mgmt_net:
+                                    self.logger.debug(f"[NodeIP] {node_name}: cluster/status IP {node_direct_ip} not in mgmt network {primary_network}, skipping quick path")
+                                elif _quick_probe(node_direct_ip, port=ssh_port):
+                                    self.logger.info(f"[NodeIP] {node_name} -> {node_direct_ip} (from cluster/status, reachable on :{ssh_port})")
+                                    return node_direct_ip
+                                else:
+                                    self.logger.debug(f"[NodeIP] {node_name}: cluster/status IP {node_direct_ip} not reachable on :{ssh_port}, continuing...")
+                            break
+            except Exception as e:
+                self.logger.debug(f"[NodeIP] cluster/status quick path failed: {e}")
             
             # ================================================================
             # STEP 2: Get ALL network interfaces from the TARGET node
@@ -6598,16 +6616,16 @@ echo "AGENT_INSTALLED_OK"
             candidates.sort(key=lambda x: x[0], reverse=True)
             
             # ================================================================
-            # STEP 3: Try candidates with connectivity probe
+            # STEP 3: Try candidates with connectivity probe (SSH port)
             # ================================================================
             for score, ip, iface, reason in candidates:
                 if score < 20 or ip == primary_ip:
                     continue
-                if _quick_probe(ip):
-                    self.logger.info(f"[NodeIP] {node_name} -> {ip} (score={score}, {reason}) reachable")
+                if _quick_probe(ip, port=ssh_port):
+                    self.logger.info(f"[NodeIP] {node_name} -> {ip} (score={score}, {reason}) reachable on :{ssh_port}")
                     return ip
                 else:
-                    self.logger.debug(f"[NodeIP] {node_name}: {ip} score={score} NOT reachable")
+                    self.logger.debug(f"[NodeIP] {node_name}: {ip} score={score} NOT reachable on :{ssh_port}")
             
             # ================================================================
             # STEP 4: Corosync -- ONLY if in management network
@@ -6626,8 +6644,8 @@ echo "AGENT_INSTALLED_OK"
                                     try:
                                         la = ipaddress.ip_address(link_ip)
                                         if primary_network and la in primary_network:
-                                            if _quick_probe(link_ip):
-                                                self.logger.info(f"[NodeIP] {node_name} -> {link_ip} (corosync {key}, mgmt net) reachable")
+                                            if _quick_probe(link_ip, port=ssh_port):
+                                                self.logger.info(f"[NodeIP] {node_name} -> {link_ip} (corosync {key}, mgmt net) reachable on :{ssh_port}")
                                                 return link_ip
                                         else:
                                             self.logger.debug(f"[NodeIP] SKIP corosync {link_ip} ({key}) -- not in mgmt network")
@@ -6654,7 +6672,7 @@ echo "AGENT_INSTALLED_OK"
                 for af, socktype, proto, canonname, sa in addrs:
                     ip = sa[0]
                     if ip and ip != primary_ip and not ip.startswith('127.') and ip != '::1':
-                        if _quick_probe(ip):
+                        if _quick_probe(ip, port=ssh_port):
                             self.logger.info(f"[NodeIP] Resolved {node_name} to {ip} (DNS, {'IPv6' if af == socket.AF_INET6 else 'IPv4'})")
                             return ip
                 # If probe failed, return first result anyway

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -6617,10 +6617,19 @@ echo "AGENT_INSTALLED_OK"
             
             # ================================================================
             # STEP 3: Try candidates with connectivity probe (SSH port)
+            # Cap at 3 probes to bound latency: each probe has a 2s timeout,
+            # so worst-case (all fail) is 6s instead of N*2s.
+            # Candidates are already sorted by score desc, so the most likely
+            # management IPs are tried first.
             # ================================================================
+            probed = 0
             for score, ip, iface, reason in candidates:
                 if score < 20 or ip == primary_ip:
                     continue
+                if probed >= 3:
+                    self.logger.debug(f"[NodeIP] {node_name}: probe cap reached, skipping remaining candidates")
+                    break
+                probed += 1
                 if _quick_probe(ip, port=ssh_port):
                     self.logger.info(f"[NodeIP] {node_name} -> {ip} (score={score}, {reason}) reachable on :{ssh_port}")
                     return ip

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -6684,9 +6684,15 @@ echo "AGENT_INSTALLED_OK"
             except (socket.gaierror, OSError):
                 pass
             
-            if node_name in self.config.host:
-                return self.config.host
-            
+            # Only fall back to the connected host when node_name matches it —
+            # use self.host (actual connected node, handles failover) and
+            # self.config.host (configured primary) to avoid returning a
+            # wrong IP when the cluster has multiple nodes.
+            connected = self.host or self.config.host
+            if node_name in connected or node_name in self.config.host:
+                self.logger.debug(f"[NodeIP] {node_name} matches connected host, using {connected}")
+                return connected
+
             self.logger.warning(f"[NodeIP] No reachable management IP for {node_name}")
             return None
             


### PR DESCRIPTION
 ## Problem
                                                                                                                                                                                                                                            
  (Proxmox API) but is not reachable via SSH when the cluster network is on                                                                                                                                                                 
  a separate VLAN from the management network. This caused SSH shell, SMBIOS
  deploy, custom scripts, and node hardening to connect to the wrong IP.                                                                                                                                                                    
                                                                                                                                                                                                                                            
  ## Fix                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                            
  All SSH operations now resolve the management IP via `_get_node_ip()`, which:                                                                                                                                                           
  - detects the primary node's management interface (VLAN-aware)                                                                                                                                                                            
  - scores candidate IPs against the same network/VLAN          
  - probes the **SSH port** (not 8006) for reachability                                                                                                                                                                                     
                                                                                                                                                                                                                                          
  ## Changes                                                                                                                                                                                                                                
                                                                                                                                                                                                                                          
  - `manager.py`: `_get_node_ip()` probes SSH port instead of 8006; STEP 0                                                                                                                                                                  
    (cluster/status quick path) moved after STEP 1 so `primary_network` is                                                                                                                                                                  
    known before accepting a Corosync IP                                  
  - `nodes.py`: `get_node_ip_api` (`/nodes/<node>/ip`, used by SSH shell modal)                                                                                                                                                             
  - `nodes.py`: `deploy_smbios_autoconfig_all` and `run_custom_script`                                                                                                                                                                    
  - `nodes.py`: `get_smbios_autoconfig` status/deploy/remove/control                                                                                                                                                                        
  - `auth.py`: `get_cluster_creds_internal` (WebSocket SSH fallback)                                                                                                                                                                        
                                                                                                                                                                                                                                            
  ## Testing                                                                                                                                                                                                                                
                                                                                                                                                                                                                                          
  Verified on a cluster with dedicated Corosync VLAN (separate from management                                                                                                                                                              
  network): SSH shell, SMBIOS deploy, and custom scripts now connect to the                                                                                                                                                                 
  correct management IP.