### PR TITLE
fix: Add indication to frontend if a guest object (VM or CT) is a template

### DIFF
--- a/web/src/dashboard.js
+++ b/web/src/dashboard.js
@@ -7190,6 +7190,7 @@
                 if (idx === -1) return text;
                 return React.createElement(React.Fragment, null, text.slice(0, idx), React.createElement('span', {style: {color: 'var(--corp-accent)', fontWeight: 600}}, text.slice(idx, idx + search.length)), text.slice(idx + search.length));
             };
+            const isSidebarGuestTemplate = (guest = {}) => guest.template === 1 || guest.template === '1' || guest.template === true;
 
             // LW: Feb 2026 - corporate inline inventory tree: nodes + VMs flat under cluster
             const renderInlineNodeTree = (clusterId) => {
@@ -7342,6 +7343,11 @@
                                         }
                                         {vmRunning && <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full" style={{background: vm.type === 'lxc' ? 'var(--corp-accent)' : 'var(--color-success)'}} />}
                                     </span>
+                                    {isSidebarGuestTemplate(vm) && (
+                                        <span className="flex-shrink-0" title="Template" style={{color: '#e9ecef'}}>
+                                            <Icons.Template className="w-3.5 h-3.5" />
+                                        </span>
+                                    )}
                                     <span className="truncate flex-1">{highlightMatch(vm.name || `${vm.type === 'lxc' ? 'CT' : 'VM'} ${vm.vmid}`, sidebarSearch)}</span>
                                 </div>
                             );
@@ -7429,6 +7435,11 @@
                                 }
                                 {vmRunning && <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full" style={{background: vm.type === 'lxc' ? '#49afd9' : '#60b515'}} />}
                             </span>
+                            {isSidebarGuestTemplate(vm) && (
+                                <span className="flex-shrink-0" title="Template" style={{color: '#e9ecef'}}>
+                                    <Icons.Template className="w-3 h-3" />
+                                </span>
+                            )}
                             <span className="truncate flex-1">{vm.name || `${vm.type === 'lxc' ? 'CT' : 'VM'} ${vm.vmid}`}</span>
                         </div>
                     );
@@ -7809,7 +7820,7 @@
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 if (!selectedCluster || selectedCluster.id !== clusterId) setSelectedCluster(clusters.find(c => c.id === clusterId));
-                                                                setSelectedSidebarVm({ vmid: vm.vmid, name: vm.name, node: vm.node, type: vm.type, status: vm.status });
+                                                                setSelectedSidebarVm({...vm, _clusterId: clusterId});
                                                                 setSelectedSidebarNode(null); setSelectedSidebarDatastore(null); setSelectedSidebarNetwork(null);
                                                                 setActiveTab('resources');
                                                             }}
@@ -7825,6 +7836,11 @@
                                                                 }
                                                                 {isRunning && <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full" style={{background: vm.type === 'lxc' ? 'var(--corp-accent)' : 'var(--color-success)'}} />}
                                                             </span>
+                                                            {isSidebarGuestTemplate(vm) && (
+                                                                <span className="flex-shrink-0" title="Template" style={{color: '#e9ecef'}}>
+                                                                    <Icons.Template className="w-3 h-3" />
+                                                                </span>
+                                                            )}
                                                             <span className="truncate">{vm.name || `${vm.type === 'lxc' ? 'CT' : 'VM'} ${vm.vmid}`}</span>
                                                             <span className="text-[10px] ml-auto flex-shrink-0" style={{color: '#5a7a8a'}}>{vm.iface}</span>
                                                         </div>

--- a/web/src/icons.js
+++ b/web/src/icons.js
@@ -254,6 +254,12 @@
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
             ),
+            Template: ({ className, style } = {}) => (
+                <svg className={className || "w-4 h-4"} style={style} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7a2 2 0 012-2h8a2 2 0 012 2v8a2 2 0 01-2 2h-8a2 2 0 01-2-2V7z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 9v10a2 2 0 002 2h10" />
+                </svg>
+            ),
             Container: () => (
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />

--- a/web/src/tables.js
+++ b/web/src/tables.js
@@ -47,6 +47,27 @@
             window.open(url, '_blank', 'noopener,noreferrer');
         }
 
+        function isGuestTemplate(resource = {}) {
+            return resource.template === 1 || resource.template === '1' || resource.template === true;
+        }
+
+        function getGuestTypeLabel(resource = {}) {
+            return resource.type === 'qemu' ? 'VM' : 'LXC';
+        }
+
+        function getGuestTypeIcon(resource = {}) {
+            return resource.type === 'qemu' ? <Icons.VM /> : <Icons.Container />;
+        }
+
+        function getTemplateLabel(t) {
+            return t('template') || 'Template';
+        }
+
+        function getGuestTypeTitle(resource = {}, t) {
+            const typeLabel = getGuestTypeLabel(resource);
+            return isGuestTemplate(resource) ? `${typeLabel} (${getTemplateLabel(t)})` : typeLabel;
+        }
+
         // Node Card Component
         function NodeCard({ name, metrics, index, clusterId, onMaintenanceToggle, onStartUpdate, onOpenNodeConfig, onNodeAction, onRemoveNode, onMoveNode }) {
             const { t } = useTranslation();
@@ -1738,8 +1759,11 @@
                                                     onChange={() => toggleSelect(resource)}
                                                     className="w-4 h-4 rounded border-proxmox-border bg-proxmox-dark text-proxmox-orange"
                                                 />
-                                                <div className={`p-2 rounded-lg ${resource.type === 'qemu' ? 'bg-blue-500/10' : 'bg-purple-500/10'}`}>
-                                                    {resource.type === 'qemu' ? <Icons.VM /> : <Icons.Container />}
+                                                <div
+                                                    className={`p-2 rounded-lg ${isGuestTemplate(resource) ? 'bg-gray-200/60 text-gray-700 border border-gray-300/40' : resource.type === 'qemu' ? 'bg-blue-500/10' : 'bg-purple-500/10'}`}
+                                                    title={getGuestTypeTitle(resource, t)}
+                                                >
+                                                    {getGuestTypeIcon(resource)}
                                                 </div>
                                                 <div>
                                                     <div className={`font-medium truncate ${onVmNavigate ? 'text-blue-400 hover:text-blue-300 hover:underline cursor-pointer' : 'text-white'}`} style={{maxWidth:'min(200px, 20vw)'}} onClick={onVmNavigate ? (e) => { e.stopPropagation(); onVmNavigate(resource); } : undefined}>
@@ -2100,12 +2124,17 @@
                                                 </td>
                                                 <td className="px-4 py-3">
                                                     <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium ${
-                                                        resource.type === 'qemu' 
+                                                        isGuestTemplate(resource)
+                                                            ? 'bg-gray-200/60 text-gray-700 border border-gray-300/40'
+                                                            : resource.type === 'qemu' 
                                                             ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
                                                             : 'bg-purple-500/10 text-purple-400 border border-purple-500/20'
-                                                    }`}>
-                                                        {resource.type === 'qemu' ? <Icons.VM /> : <Icons.Container />}
-                                                        {resource.type === 'qemu' ? 'VM' : 'LXC'}
+                                                    }`} title={getGuestTypeTitle(resource, t)}>
+                                                        {getGuestTypeIcon(resource)}
+                                                        {getGuestTypeLabel(resource)}
+                                                        {isGuestTemplate(resource) && (
+                                                            <span className="text-amber-300">({getTemplateLabel(t)})</span>
+                                                        )}
                                                     </span>
                                                 </td>
                                                 <td className="px-4 py-3">
@@ -2385,8 +2414,11 @@
                                                     : 'hover:bg-proxmox-dark/50'
                                             }`}
                                         >
-                                            <div className={`p-1.5 rounded ${resource.type === 'qemu' ? 'bg-blue-500/10' : 'bg-purple-500/10'}`}>
-                                                {resource.type === 'qemu' ? <Icons.VM /> : <Icons.Container />}
+                                            <div
+                                                className={`p-1.5 rounded ${isGuestTemplate(resource) ? 'bg-gray-300/50 text-gray-800 border border-gray-400/50' : resource.type === 'qemu' ? 'bg-blue-500/10' : 'bg-purple-500/10'}`}
+                                                title={getGuestTypeTitle(resource, t)}
+                                            >
+                                                {getGuestTypeIcon(resource)}
                                             </div>
                                             <div className="flex-1 min-w-0">
                                                 <div className="font-medium text-white text-sm truncate">


### PR DESCRIPTION
fix: Add indication to frontend if a guest object (VM or CT) is a template

## Example
<img width="872" height="544" alt="pegaprox_template_indication" src="https://github.com/user-attachments/assets/cb508e78-c684-43bf-8b8e-b4b17e3f5c4d" />
