### PR TITLE
feature: Add syslog scoping

### DIFF
--- a/pegaprox/api/helpers.py
+++ b/pegaprox/api/helpers.py
@@ -80,6 +80,9 @@ def load_server_settings():
         # MK Apr 2026 — when true, /api/metrics needs no auth. Useful for setups
         # where a reverse proxy/mutual-TLS already gates scrapes. Default off.
         'metrics_public': False,
+        # When enabled, the Syslog viewer only shows hostnames belonging to
+        # the currently selected cluster instead of all collected syslog rows.
+        'syslog_filter_by_selected_cluster': False,
         # Webhook alert channels (Slack, Discord, Teams, ntfy, generic)
         # Each: {id, name, type, url, enabled, ...type-specific fields}
         'alert_webhooks': [],

--- a/pegaprox/api/reports.py
+++ b/pegaprox/api/reports.py
@@ -7,6 +7,7 @@ import logging
 import re
 import sqlite3
 import threading
+from urllib.parse import urlparse
 from datetime import datetime, timedelta
 from flask import Blueprint, jsonify, request
 
@@ -16,7 +17,7 @@ from pegaprox.models.permissions import *
 
 from pegaprox.utils.auth import require_auth, load_users
 from pegaprox.utils.rbac import get_user_clusters
-from pegaprox.api.helpers import check_cluster_access
+from pegaprox.api.helpers import check_cluster_access, load_server_settings
 from pegaprox.background.metrics import load_metrics_history, start_metrics_collector
 from pegaprox.background.syslog_server import DB_FILE, SEVERITY_MAP
 from pegaprox.api.schedules import start_scheduler
@@ -56,6 +57,53 @@ def _syslog_like_clause(search_text):
         )""",
         [like, like, like, like, like, like],
     )
+
+
+def _syslog_hostname_tokens(value):
+    value = str(value or '').strip().lower()
+    if not value:
+        return set()
+    if '://' in value:
+        parsed = urlparse(value)
+        value = parsed.hostname or value
+    value = value.split('/')[0].split('@')[-1]
+    if value.startswith('[') and ']' in value:
+        value = value[1:value.index(']')]
+    elif ':' in value and value.count(':') == 1:
+        value = value.rsplit(':', 1)[0]
+    value = value.strip('.')
+    if not value:
+        return set()
+    tokens = {value}
+    if '.' in value:
+        tokens.add(value.split('.', 1)[0])
+    return tokens
+
+
+def _syslog_cluster_hostnames(cluster_id):
+    manager = cluster_managers.get(cluster_id)
+    if not manager:
+        return set()
+
+    hostnames = set()
+    config = getattr(manager, 'config', None)
+    for value in (
+        getattr(manager, 'host', ''),
+        getattr(config, 'host', '') if config else '',
+        getattr(config, 'name', '') if config else '',
+    ):
+        hostnames.update(_syslog_hostname_tokens(value))
+
+    try:
+        node_status = manager.get_node_status() or {}
+        for node_name in node_status.keys():
+            hostnames.update(_syslog_hostname_tokens(node_name))
+    except Exception as exc:
+        logging.debug(f"[Syslog] Could not load nodes for cluster filter {cluster_id}: {exc}")
+        for node_name in getattr(manager, 'ha_node_status', {}).keys():
+            hostnames.update(_syslog_hostname_tokens(node_name))
+
+    return hostnames
 
 @bp.route('/api/reports/summary', methods=['GET'])
 @require_auth()
@@ -180,6 +228,7 @@ def get_integrated_syslog_events():
     hostname = (request.args.get('hostname') or '').strip()
     source_ip = (request.args.get('source_ip') or '').strip()
     facility = (request.args.get('facility') or '').strip()
+    cluster_id = (request.args.get('cluster_id') or '').strip()
 
     sort_map = {
         'id': 'logs.id',
@@ -266,6 +315,22 @@ def get_integrated_syslog_events():
             params.append(facility_value)
         except ValueError:
             pass
+
+    if cluster_id and load_server_settings().get('syslog_filter_by_selected_cluster', False):
+        ok, err = check_cluster_access(cluster_id)
+        if not ok:
+            return err
+        cluster_hostnames = sorted(_syslog_cluster_hostnames(cluster_id))
+        if cluster_hostnames:
+            cluster_hostname_where = []
+            for value in cluster_hostnames:
+                cluster_hostname_where.append("LOWER(logs.hostname) = ?")
+                params.append(value)
+                cluster_hostname_where.append("LOWER(logs.hostname) LIKE ?")
+                params.append(f"{value}.%")
+            where.append(f"({' OR '.join(cluster_hostname_where)})")
+        else:
+            where.append("1 = 0")
 
     where_sql = f"WHERE {' AND '.join(where)}" if where else ''
     joins_sql = f"{' '.join(joins)}" if joins else ''

--- a/pegaprox/api/settings.py
+++ b/pegaprox/api/settings.py
@@ -1152,6 +1152,12 @@ def update_server_settings():
                 settings['alert_update_available'] = bool(data['alert_update_available'])
             if 'metrics_public' in data:
                 settings['metrics_public'] = bool(data['metrics_public'])
+            if 'syslog_filter_by_selected_cluster' in data:
+                old_val = settings.get('syslog_filter_by_selected_cluster', False)
+                settings['syslog_filter_by_selected_cluster'] = bool(data['syslog_filter_by_selected_cluster'])
+                if old_val != settings['syslog_filter_by_selected_cluster']:
+                    log_audit(request.session.get('user', 'admin'), 'settings.syslog',
+                              f"Syslog cluster hostname filter {'enabled' if settings['syslog_filter_by_selected_cluster'] else 'disabled'}")
             if 'strict_session_ip' in data:
                 settings['strict_session_ip'] = bool(data['strict_session_ip'])
 
@@ -1381,6 +1387,12 @@ def update_server_settings():
                 settings['alert_cooldown'] = max(60, min(86400, int(request.form['alert_cooldown'])))
             if 'alert_update_available' in request.form:
                 settings['alert_update_available'] = request.form['alert_update_available'] in ('true', '1', 'on')
+            if 'syslog_filter_by_selected_cluster' in request.form:
+                old_syslog_filter = settings.get('syslog_filter_by_selected_cluster', False)
+                settings['syslog_filter_by_selected_cluster'] = request.form['syslog_filter_by_selected_cluster'] in ('true', '1', 'on')
+                if old_syslog_filter != settings['syslog_filter_by_selected_cluster']:
+                    log_audit(request.session.get('user', 'admin'), 'settings.syslog',
+                              f"Syslog cluster hostname filter {'enabled' if settings['syslog_filter_by_selected_cluster'] else 'disabled'}")
 
             # Handle certificate upload
             if 'ssl_cert' in request.files:
@@ -4572,6 +4584,5 @@ def test_ldap():
         results['steps'].append({'step': failed_step, 'status': 'error', 'detail': str(e)})
     
     return jsonify(results)
-
 
 

--- a/web/src/dashboard.js
+++ b/web/src/dashboard.js
@@ -8246,6 +8246,9 @@
                         sort_by: sortBy,
                         sort_dir: sortDir
                     });
+                    if (selectedCluster?.id) {
+                        params.set('cluster_id', selectedCluster.id);
+                    }
 
                     Object.entries(filters || {}).forEach(([key, value]) => {
                         if (value !== null && value !== undefined && String(value).trim() !== '') {

--- a/web/src/settings_modal.js
+++ b/web/src/settings_modal.js
@@ -727,6 +727,7 @@
                 alert_email_recipients: [],
                 alert_cooldown: 300,
                 alert_update_available: false,
+                syslog_filter_by_selected_cluster: false,
             });
             const [serverLoading, setServerLoading] = useState(false);
             const [showRestartConfirm, setShowRestartConfirm] = useState(false);
@@ -1526,6 +1527,7 @@
                             alert_email_recipients: data.alert_email_recipients || [],
                             alert_cooldown: data.alert_cooldown || 300,
                             alert_update_available: !!data.alert_update_available,
+                            syslog_filter_by_selected_cluster: !!data.syslog_filter_by_selected_cluster,
                             // Security settings
                             login_max_attempts: data.login_max_attempts || 5,
                             login_lockout_time: data.login_lockout_time || 300,
@@ -1731,6 +1733,7 @@
                         formData.append('alert_cooldown', serverSettings.alert_cooldown);
                     }
                     formData.append('alert_update_available', serverSettings.alert_update_available ? 'true' : 'false');
+                    formData.append('syslog_filter_by_selected_cluster', serverSettings.syslog_filter_by_selected_cluster ? 'true' : 'false');
 
                     if (serverSettings.ssl_cert_file) {
                         formData.append('ssl_cert', serverSettings.ssl_cert_file);
@@ -2432,6 +2435,17 @@
                             >
                                 <Icons.Server className="w-4 h-4" />
                                 <span>{t('server') || 'Server'}</span>
+                            </button>
+                            <button
+                                onClick={() => setActiveTab('syslog')}
+                                className={`flex items-center gap-2 ${isCorporate ? 'px-3 py-1.5 text-[13px]' : 'px-4 py-2.5 text-sm'} font-medium transition-colors whitespace-nowrap ${
+                                    activeTab === 'syslog'
+                                        ? (isCorporate ? 'text-white border-b-2 border-[#49afd9] font-medium' : 'text-proxmox-orange border-b-2 border-proxmox-orange bg-proxmox-dark/50')
+                                        : 'text-gray-400 hover:text-white hover:bg-proxmox-dark/30'
+                                }`}
+                            >
+                                <Icons.FileText className="w-4 h-4" />
+                                <span>{t('syslogServer') || 'Syslog Server'}</span>
                             </button>
                             <button
                                 onClick={() => setActiveTab('audit')}
@@ -5299,7 +5313,70 @@
                                     </div>
                                 </div>
                             )}
-                            
+
+                            {/* Syslog Server Settings Tab */}
+                            {activeTab === 'syslog' && (
+                                <div className="space-y-6">
+                                    <h3 className="text-lg font-semibold text-white">{t('syslogServer') || 'Syslog Server'}</h3>
+
+                                    <div className="bg-proxmox-dark border border-proxmox-border rounded-xl p-4 space-y-4">
+                                        <div className="flex items-center justify-between gap-4">
+                                            <div>
+                                                <h4 className="font-medium text-white flex items-center gap-2">
+                                                    <Icons.FileText />
+                                                    {t('syslogClusterFilter') || 'Cluster-scoped syslog viewer'}
+                                                </h4>
+                                                <p className="text-sm text-gray-400 mt-1">
+                                                    {t('syslogClusterFilterDesc') || 'When enabled, the Syslog chapter only shows log rows whose hostname belongs to the selected cluster or one of its nodes.'}
+                                                </p>
+                                            </div>
+                                            <label className="flex items-center gap-2 cursor-pointer shrink-0">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={!!serverSettings.syslog_filter_by_selected_cluster}
+                                                    onChange={e => setServerSettings({...serverSettings, syslog_filter_by_selected_cluster: e.target.checked})}
+                                                    className="rounded border-proxmox-border bg-proxmox-darker"
+                                                />
+                                                <span className="text-sm text-gray-300">{t('enabled') || 'Enabled'}</span>
+                                            </label>
+                                        </div>
+
+                                        <div className="pt-3 flex justify-end border-t border-proxmox-border">
+                                            <button
+                                                onClick={async () => {
+                                                    setServerLoading(true);
+                                                    try {
+                                                        const response = await fetch(`${API_URL}/settings/server`, {
+                                                            method: 'POST',
+                                                            credentials: 'include',
+                                                            headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
+                                                            body: JSON.stringify({
+                                                                syslog_filter_by_selected_cluster: !!serverSettings.syslog_filter_by_selected_cluster
+                                                            })
+                                                        });
+                                                        if (response && response.ok) {
+                                                            addToast(t('settingsSaved') || 'Settings saved', 'success');
+                                                            fetchServerSettings();
+                                                        } else {
+                                                            const err = await response.json().catch(() => ({}));
+                                                            addToast(err.error || t('errorSavingSettings') || 'Error saving settings', 'error');
+                                                        }
+                                                    } catch (err) {
+                                                        addToast(t('errorSavingSettings') || 'Error saving settings', 'error');
+                                                    }
+                                                    setServerLoading(false);
+                                                }}
+                                                disabled={serverLoading}
+                                                className="px-4 py-2 bg-proxmox-orange hover:bg-orange-600 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 flex items-center gap-2"
+                                            >
+                                                {serverLoading && <Icons.Loader className="w-4 h-4 animate-spin" />}
+                                                {t('saveSettings') || t('save') || 'Save'}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
                             {/* Server Settings Tab */}
                             {activeTab === 'server' && (
                                 <div className="space-y-6">

--- a/web/src/translations.js
+++ b/web/src/translations.js
@@ -68,6 +68,9 @@
                 cmVsnfdSecureBoot: 'Secure-Boot-Status',
                 forceDeletePlan: 'Diesen hängenden Plan zwangsweise löschen?',
                 refresh: 'Aktualisieren',
+                syslogServer: 'Syslog Server',
+                syslogClusterFilter: 'Cluster-begrenzter Syslog-Viewer',
+                syslogClusterFilterDesc: 'Wenn aktiviert, zeigt das Syslog-Kapitel nur Logzeilen, deren Hostname zum ausgewählten Cluster oder seinen Nodes gehört.',
 
                 // General
                 loading: 'Laden...',
@@ -3845,6 +3848,9 @@
                 cmVsnfdSecureBoot: 'Secure Boot status',
                 forceDeletePlan: 'Force-delete this stuck plan?',
                 refresh: 'Refresh',
+                syslogServer: 'Syslog Server',
+                syslogClusterFilter: 'Cluster-scoped syslog viewer',
+                syslogClusterFilterDesc: 'When enabled, the Syslog chapter only shows log rows whose hostname belongs to the selected cluster or one of its nodes.',
 
                 // General
                 loading: 'Loading...',


### PR DESCRIPTION
feature: Add syslog scoping
  Allow administrators to toggle between viewing all
  syslog events from inbound messages, regardless of
  scope, or restricting the syslog viewer to nodes
  belonging to the selected cluster.

Fixes: #387
Sponsored-by: credativ GmbH (https://credativ.de)