### PR TITLE
web: show guest-agent IP in VM Hardware box

### DIFF
--- a/web/src/vm_modals.js
+++ b/web/src/vm_modals.js
@@ -2011,6 +2011,14 @@
                                                 <span style={{color: '#e9ecef'}}>{vmHwInfo.net}</span>
                                             </div>
                                         )}
+                                        {/* IP (from QEMU guest agent) */}
+                                        {isQemu && isRunning && guestInfo?.ip_addresses?.length > 0 && (
+                                            <div className="flex items-center gap-2 text-[12px]">
+                                                <Icons.Globe className="w-3.5 h-3.5 flex-shrink-0" style={{color: '#49afd9'}} />
+                                                <span style={{color: '#adbbc4', width: '60px'}}>IP</span>
+                                                <span style={{color: '#e9ecef', fontFamily: 'monospace', fontSize: '11px'}}>{guestInfo.ip_addresses.join(', ')}</span>
+                                            </div>
+                                        )}
                                         {/* BIOS/Machine */}
                                         {vmHwInfo && (
                                             <div className="flex items-center gap-2 text-[12px]">

--- a/web/src/vm_modals.js
+++ b/web/src/vm_modals.js
@@ -2013,10 +2013,16 @@
                                         )}
                                         {/* IP (from QEMU guest agent) */}
                                         {isQemu && isRunning && guestInfo?.ip_addresses?.length > 0 && (
-                                            <div className="flex items-center gap-2 text-[12px]">
-                                                <Icons.Globe className="w-3.5 h-3.5 flex-shrink-0" style={{color: '#49afd9'}} />
-                                                <span style={{color: '#adbbc4', width: '60px'}}>IP</span>
-                                                <span style={{color: '#e9ecef', fontFamily: 'monospace', fontSize: '11px'}}>{guestInfo.ip_addresses.join(', ')}</span>
+                                            <div className="flex items-start gap-2 text-[12px]">
+                                                <Icons.Globe className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" style={{color: '#49afd9'}} />
+                                                <span className="flex-shrink-0" style={{color: '#adbbc4', width: '60px'}}>IP</span>
+                                                <span
+                                                    className="flex-1 min-w-0 break-all"
+                                                    style={{color: '#e9ecef', fontFamily: 'monospace', fontSize: '11px'}}
+                                                    title={guestInfo.ip_addresses.join(', ')}
+                                                >
+                                                    {guestInfo.ip_addresses.join(', ')}
+                                                </span>
                                             </div>
                                         )}
                                         {/* BIOS/Machine */}


### PR DESCRIPTION
## Summary
- Adds an **IP** row inside the *VM Hardware* panel of the VM detail view, populated from the QEMU guest agent (`guestInfo.ip_addresses`).
- Only renders for running QEMU VMs that have the guest agent reporting addresses — falls back silently otherwise.
- Visually matches the existing CPU / Memory / Network rows (Globe icon, 60px label column, monospace value).
- Wraps long multi-IP lists (IPv4 + IPv6) inside the panel instead of overflowing, with a `title` tooltip showing the full joined list.

The same data was already exposed in the separate *Guest Agent Info* card to the right; this PR mirrors it into the Hardware panel so it sits alongside the other per-VM resources.

## Test plan
- [ ] Open a running QEMU VM that has `qemu-guest-agent` installed — IP row appears under Network inside *VM Hardware*.
- [ ] Open a running QEMU VM without the guest agent — row is hidden, layout unchanged.
- [ ] Open a stopped VM — row is hidden.
- [ ] Open an LXC container — row is hidden (gated by `isQemu`).
- [ ] VM with many IPv4 + IPv6 addresses — value wraps inside the panel, no horizontal overflow.
