### PR TITLE
fix: Disallow ISO sync on shared storage within a cluster.

### DIFF
--- a/pegaprox/api/storage.py
+++ b/pegaprox/api/storage.py
@@ -2467,8 +2467,14 @@ def iso_sync_trigger(cluster_id):
     content_type = data.get('content_type', 'iso')
     targets = data.get('target_nodes')
 
+    if content_type not in ('iso', 'vztmpl'):
+        return jsonify({'error': 'content_type must be iso or vztmpl'}), 400
     if not all([source, storage, filename]):
         return jsonify({'error': 'source_node, storage, filename required'}), 400
+    if hasattr(mgr, '_get_syncable_storage'):
+        _, storage_err = mgr._get_syncable_storage(source, storage, content_type)
+        if storage_err:
+            return jsonify({'error': storage_err}), 400
 
     def _do_sync():
         results = mgr.sync_content_to_nodes(source, storage, filename, content_type, targets)
@@ -2488,6 +2494,8 @@ def iso_sync_all(cluster_id):
     mgr = cluster_managers[cluster_id]
     data = request.get_json() or {}
     content_type = data.get('content_type', 'iso')
+    if content_type not in ('iso', 'vztmpl'):
+        return jsonify({'error': 'content_type must be iso or vztmpl'}), 400
 
     def _do_sync_all():
         status = mgr.get_content_sync_status(content_type)
@@ -2519,4 +2527,3 @@ def iso_sync_last_result(cluster_id):
     mgr = cluster_managers[cluster_id]
     result = getattr(mgr, '_sync_last_result', None)
     return jsonify(result or {})
-

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -10648,6 +10648,30 @@ echo "AGENT_INSTALLED_OK"
     
     # LW: Apr 2026 - ISO/Template sync across cluster nodes
     # for iSCSI-only setups where file-level storage isn't shared
+    @staticmethod
+    def _storage_is_shared(storage):
+        """Return True when a Proxmox storage entry is marked shared."""
+        shared = storage.get('shared', 0) if isinstance(storage, dict) else 0
+        if isinstance(shared, bool):
+            return shared
+        if isinstance(shared, (int, float)):
+            return shared != 0
+        return str(shared).strip().lower() in ('1', 'true', 'yes', 'on')
+
+    def _get_syncable_storage(self, node, storage_name, content_type='iso'):
+        """Find a non-shared storage that can participate in ISO/template sync."""
+        for storage in self.get_storage_list(node):
+            if storage.get('storage') != storage_name:
+                continue
+            if content_type not in storage.get('content', ''):
+                return None, f"Storage {storage_name} does not support {content_type}"
+            if self._storage_is_shared(storage):
+                return None, f"Storage {storage_name} is shared; ISO sync is only available for non-shared storage"
+            if not storage.get('active'):
+                return None, f"Storage {storage_name} is not active on {node}"
+            return storage, None
+        return None, f"Storage {storage_name} not found on {node}"
+
     def get_content_sync_status(self, content_type='iso'):
         """Build matrix of which ISOs/templates exist on which nodes"""
         if not self.is_connected:
@@ -10660,7 +10684,9 @@ echo "AGENT_INSTALLED_OK"
             node_files = {}
             for node in online_nodes:
                 storages = [s for s in self.get_storage_list(node)
-                            if content_type in s.get('content', '') and s.get('active')]
+                            if content_type in s.get('content', '')
+                            and s.get('active')
+                            and not self._storage_is_shared(s)]
                 files = []
                 for stor in storages:
                     url = f"https://{host}:{self.api_port}/api2/json/nodes/{node}/storage/{stor['storage']}/content"
@@ -10706,6 +10732,10 @@ echo "AGENT_INSTALLED_OK"
         if not self.is_connected:
             return [{'error': 'Not connected'}]
 
+        _, err = self._get_syncable_storage(source_node, storage, content_type)
+        if err:
+            return [{'error': err}]
+
         ns = self.get_node_status()
         online_nodes = [n for n, d in ns.items() if d.get('status') == 'online' and n != source_node]
         if target_nodes:
@@ -10725,6 +10755,10 @@ echo "AGENT_INSTALLED_OK"
 
         for tgt_node in online_nodes:
             tgt_ip = self._get_node_ip(tgt_node) or tgt_node
+            _, err = self._get_syncable_storage(tgt_node, storage, content_type)
+            if err:
+                results.append({'node': tgt_node, 'success': False, 'error': err})
+                continue
             tgt_path = self._resolve_storage_path(tgt_node, storage, content_type)
             if not tgt_path:
                 results.append({'node': tgt_node, 'success': False, 'error': f'Storage {storage} not on {tgt_node}'})
@@ -14205,4 +14239,3 @@ echo DONE""",
             self.thread.join(timeout=5)
         self.running = False
         self.logger.info(f"Stopped PegaProx manager for {self.config.name}")
-


### PR DESCRIPTION
fix: Disallow ISO sync on shared storage within a cluster.
  ISO sync might end up in confusions when using shared
  storage in a cluster where all data is already present
  for all nodes (unless explicitly excluded).

Details:
This simply doesn't show up for storage types that are declared by `shared: 1`, as all data is already available for all nodes.
 
Result in UI:
ISOs on storages that are defined as shared should not be visible, as there isn't any need for a sync. Attached, an example of an ISO of 'griml' on a shared NFS which won't get shown anymore while the local ISOs on the nodes LVM are still present:
<img width="1796" height="855" alt="pegaprox_iso_sync_test" src="https://github.com/user-attachments/assets/57384afa-d5d6-4911-8140-616bbadcaea3" />

Sponsored-by: credativ GmbH <https://credativ.de>