### PR TITLE
fix(#419 follow-up): NodeCard treats netin/netout as counter, sparkline collapses to 0.0 MB/s

### DIFF
--- a/pegaprox/core/xcpng.py
+++ b/pegaprox/core/xcpng.py
@@ -103,7 +103,6 @@ class XcpngManager:
         # node/vm caches
         self._cached_nodes = None
         self._nodes_cache_time = 0
-        self._net_accum = {}  # LW: accumulate rate→cumulative for frontend compat
         self._nodes_cache_ttl = 8  # seconds, same as PegaProxManager
         self._cached_vms = None
         self._vms_cache_time = 0
@@ -403,18 +402,11 @@ class XcpngManager:
             product_brand = sw_ver.get('product_brand', 'XCP-ng')
             xen_ver = sw_ver.get('xen', '')
 
-            # LW: frontend expects cumulative byte counters (like Proxmox), not rates
-            # accumulate rate * dt to simulate cumulative values
+            # #419 follow-up: emit node netin/netout as bytes/sec rate to match the
+            # post-#419 Proxmox contract on /api/clusters/<id>/metrics. NodeCard now
+            # consumes a rate directly; the previous accumulator-to-counter dance is
+            # no longer needed.
             hostname = _sanitize_str(rec.get('hostname', rec.get('name_label', '')))
-            now = time.time()
-            if hostname not in self._net_accum:
-                self._net_accum[hostname] = {'in': 0, 'out': 0, 't': now}
-            acc = self._net_accum[hostname]
-            dt = now - acc['t']
-            if dt > 0 and dt < 120:  # skip if gap too large (reconnect etc)
-                acc['in'] += netin * dt
-                acc['out'] += netout * dt
-            acc['t'] = now
 
             nodes.append({
                 'node': hostname,
@@ -427,8 +419,8 @@ class XcpngManager:
                 'mem': mem_total - mem_free,
                 'maxmem': mem_total,
                 'uptime': uptime_secs,
-                'netin': acc['in'],
-                'netout': acc['out'],
+                'netin': netin,
+                'netout': netout,
                 'type': 'node',
                 '_enabled': rec.get('enabled', True),
                 '_ref': ref,

--- a/web/src/tables.js
+++ b/web/src/tables.js
@@ -90,7 +90,6 @@
             const [actionLoading, setActionLoading] = useState(null);
             const [expanded, setExpanded] = useState(false);
             const lastMetricsRef = useRef(null);
-            const lastNetRef = useRef({ netin: 0, netout: 0, time: Date.now() });
 
             // auto-dismiss update banner after 30s when completed (#183)
             useEffect(() => {
@@ -110,20 +109,15 @@
             useEffect(() => {
                 if (metrics && metrics !== lastMetricsRef.current) {
                     lastMetricsRef.current = metrics;
-                    
-                    // calc network rate
-                    const now = Date.now();
-                    const timeDiff = (now - lastNetRef.current.time) / 1000;
-                    const netinRate = timeDiff > 0 ? Math.max(0, (metrics.netin - lastNetRef.current.netin) / timeDiff) : 0;
-                    const netoutRate = timeDiff > 0 ? Math.max(0, (metrics.netout - lastNetRef.current.netout) / timeDiff) : 0;
-                    lastNetRef.current = { netin: metrics.netin || 0, netout: metrics.netout || 0, time: now };
-                    
+
+                    // #419 follow-up: backend netin/netout are already a rate (bytes/sec, rrddata AVERAGE),
+                    // not a cumulative counter — divide directly, no delta-over-time.
                     historyRef.current = {
                         cpu: [...historyRef.current.cpu.slice(1), metrics.cpu_percent || 0],
                         mem: [...historyRef.current.mem.slice(1), metrics.mem_percent || 0],
                         disk: [...historyRef.current.disk.slice(1), metrics.disk_percent || 0],
-                        netin: [...historyRef.current.netin.slice(1), netinRate / 1048576], // MB/s
-                        netout: [...historyRef.current.netout.slice(1), netoutRate / 1048576]
+                        netin: [...historyRef.current.netin.slice(1), (metrics.netin || 0) / 1048576], // MB/s
+                        netout: [...historyRef.current.netout.slice(1), (metrics.netout || 0) / 1048576]
                     };
                     forceUpdate(n => n + 1);
                 }

--- a/web/src/tables.js
+++ b/web/src/tables.js
@@ -121,7 +121,7 @@
                     };
                     forceUpdate(n => n + 1);
                 }
-            }, [metrics?.cpu_percent, metrics?.mem_percent, metrics?.netin, metrics?.netout]);
+            }, [metrics?.cpu_percent, metrics?.mem_percent, metrics?.disk_percent, metrics?.netin, metrics?.netout]);
             
             const history = historyRef.current;
 


### PR DESCRIPTION
## Summary

Follow-up to #419 (commit 2772f0c). That fix made the **backend** return node `netin`/`netout` as a rate (bytes/sec, rrddata `cf=AVERAGE`) instead of off `/cluster/resources?type=node` (which never had those fields for nodes). Two consumers were not aligned with the new contract:

1. `web/src/tables.js` `NodeCard` still treated the values as a cumulative counter and did `(metrics.netin - lastNetRef.current.netin) / timeDiff`. Delta of a near-stable rate ≈ 0 → `.toFixed(1)` renders `"0.0"` — the exact symptom #419 set out to fix.
2. `pegaprox/core/xcpng.py` was hand-rolling a cumulative counter on top of XAPI's rates (`acc['in'] += netin * dt`) specifically to mimic the old Proxmox contract. After (1), that accumulator would have made XCP-ng nodes show ever-growing MB/s.

This PR aligns both consumers on the **rate** contract:
- Frontend: drop counter-delta math + `lastNetRef`, divide bytes/sec → MB/s directly.
- XCP-ng backend: drop `self._net_accum` accumulator, emit XAPI's `pif_<dev>_rx`/`pif_<dev>_tx` sums as-is (already bytes/sec, same unit Proxmox returns post-#419).

(Thanks @qodo-code-review for catching the XCP-ng side — was missed in the original frontend-only patch.)

## Reproduction

Live Proxmox 9.1.11 cluster, post-v0.9.10.3:

```
GET /api/clusters/<id>/metrics
{
  "evanthoulaki": { ..., "netin": 891510.33, "netout": 505098.37 },
  "takaros":      { ..., "netin": ...,        "netout": ... }
}
```

Bytes/sec rate per #419's backend change, but the dashboard Network In/Out cards still showed `0.0 MB/s` for both nodes.

Simulated 5 polls at the live rate, 2 s apart:

| poll | old (in, out) MB/s | new (in, out) MB/s |
|------|--------------------|--------------------|
| 1    | 0.425, 0.241       | 0.850, 0.482       |
| 2    | 0.005, 0.000       | 0.859, 0.476       |
| 3    | 0.000, 0.007       | 0.843, 0.489       |
| 4    | 0.005, 0.000       | 0.854, 0.480       |
| 5    | 0.003, 0.003       | 0.860, 0.486       |

After patching `tables.js` + rebuilding `web/index.html` on the live LXC, the sparkline tracks ~0.85 MB/s in / ~0.48 MB/s out, matching backend.

## Consumer audit (XCP-ng accumulator removal)

Other consumers of XCP-ng node `netin`/`netout` checked — none depend on counter semantics:

| Path | Reads node netin/netout? | Affected? |
|---|---|---|
| `web/src/tables.js` `NodeCard` | yes (aligned in this PR) | aligned |
| `web/src/tables.js` VM detail diff (line ~1379) | VM-level only, `!==` comparator | no |
| `pegaprox/api/metrics_exporter.py` node loop | no — only `cpu_percent` / `mem_percent` / `uptime` | no |
| `pegaprox/api/metrics_exporter.py` VM loop | VM-level; XCP-ng VMs always emit 0 (`xcpng.py:567`) | no |
| `pegaprox/core/manager.py` netin/netout refs | Proxmox path only | no |

## Test plan

- [x] Reproduced on a live v0.9.10.3 Proxmox install: dashboard Network In/Out sparkline read `0.0 MB/s` while `/api/clusters/<id>/metrics` returned non-zero `netin`/`netout`.
- [x] Patched `tables.js`, rebuilt `web/index.html`, hard-refreshed → sparkline tracks live rate.
- [x] Verified `lastNetRef` has no other consumer (`grep -n lastNetRef web/src/*.js`).
- [x] Verified XCP-ng `_net_accum` / `acc['in']` / `acc['out']` have no other consumer (`grep -n` across `pegaprox/`).
- [x] `python3 -c "import ast; ast.parse(open('pegaprox/core/xcpng.py').read())"` passes.
- [ ] **Cannot test live** on XCP-ng — no XCP-ng cluster available. Maintainers please confirm node Network In/Out on an XCP-ng cluster shows current rate (~MB/s tracking actual traffic) rather than steadily increasing values.

## Files

- `web/src/tables.js` — frontend rate handling
- `web/index.html` — rebuilt via `web/Dev/build.sh`
- `pegaprox/core/xcpng.py` — drop accumulator, emit rate directly

Closes the still-open symptom from #419.