### PR TITLE
fix(logging): demote per-node status line from info to debug

### DIFF
--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -1413,7 +1413,7 @@ class PegaProxManager:
 
                         maintenance_str = " [MAINTENANCE]" if in_maintenance else ""
                         update_str = " [UPDATING]" if is_updating else ""
-                        self.logger.info(f"Node {node_name}: CPU {cpu_percent:.2f}%, RAM {mem_percent:.2f}% ({self._format_bytes(mem_used)}/{self._format_bytes(mem_total)}), Score {score:.2f}, Status: {node['status']}{maintenance_str}{update_str}")
+                        self.logger.debug(f"Node {node_name}: CPU {cpu_percent:.2f}%, RAM {mem_percent:.2f}% ({self._format_bytes(mem_used)}/{self._format_bytes(mem_total)}), Score {score:.2f}, Status: {node['status']}{maintenance_str}{update_str}")
                     else:
                         # Node exists but we couldn't get status - might be offline
                         node_status[node_name] = {


### PR DESCRIPTION
## **User description**
## Summary

`ProxmoxManager.get_node_status()` logs a per-node status line at `INFO`
on every poll. The per-cluster logger has its own `StreamHandler` floored
at `INFO`, so this line reaches stdout roughly once per second per node:

```
[2026-05-30 14:00:00,910] [PegaProx_oslo] INFO: Node oslo: CPU 16.35%, RAM 88.99% (55.33 GB/62.18 GB), Score 112.34, Status: online
```

On a multi-node setup this floods stdout and any downstream log collector
(journald, k8s logging, Loki, …) with routine metrics that carry no
actionable signal at the default verbosity.

## Change

Demote that single line from `logger.info` to `logger.debug` in
`pegaprox/core/manager.py`. The metrics are still available:

- in the web UI and the in-memory node-metrics history buffer (unchanged),
- in the logs when running with `--debug` or `PEGAPROX_LOG_LEVEL=DEBUG`.

No behavior change beyond log verbosity; HA/offline alerts and other
`WARNING`/`ERROR` logs are untouched.

## Current workaround

For now I'm bypassing the noise on my side by running the whole system
at `PEGAPROX_LOG_LEVEL=WARNING`, which silences this line — at the cost
of also hiding all other `INFO` logs. This PR makes that workaround
unnecessary.

## Testing

- Ran with the default log level: the per-node line no longer appears on stdout.
- Ran with `PEGAPROX_LOG_LEVEL=DEBUG`: the line is emitted as before.


___

## **CodeAnt-AI Description**
**Stop routine node status logs from appearing at normal log level**

### What Changed
- Per-node CPU, RAM, score, and status updates no longer show up in normal logs on every poll
- These lines still appear when running in debug mode, while other warnings and errors are unchanged

### Impact
`✅ Less log noise in multi-node setups`
`✅ Smaller stdout and log collector volume`
`✅ Node metrics still available in debug runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
