### PR TITLE
fix v2p sshfs migration fallback checks

### DIFF
--- a/pegaprox/core/v2p.py
+++ b/pegaprox/core/v2p.py
@@ -3731,7 +3731,7 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
     esxi_test_path = f"/vmfs/volumes/{datastore}/{vm_dir}/{flat0}"
     
     qemu_ssh_works = False
-    rc_qtest, out_qtest, _ = _pve_node_exec(pve_mgr, task.target_node,
+    rc_qtest, out_qtest, err_qtest = _pve_node_exec(pve_mgr, task.target_node,
         f"timeout 10 qemu-img info "
         f"'json:{{\"file.driver\":\"ssh\","
         f"\"file.host\":\"{esxi_host}\","
@@ -3740,19 +3740,19 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
         f"\"file.user\":\"{esxi_user}\","
         f"\"file.host-key-check.mode\":\"none\","
         f"\"file.identity-file\":\"{key_path}\"}}' 2>&1",
-        timeout=20)
-    qtest_out = str(out_qtest or '')
+        timeout=20, ignore_node_backoff=True)
+    qtest_out = (str(out_qtest or '') + str(err_qtest or '')).strip()
     if rc_qtest == 0 and ('virtual size' in qtest_out or 'file format' in qtest_out):
         qemu_ssh_works = True
         task.log("QEMU SSH driver: connection OK")
     else:
         task.log(f"QEMU SSH driver test failed: {qtest_out[:200]}")
         # Try alternative: qemu-img with simpler SSH URL syntax
-        rc_qt2, out_qt2, _ = _pve_node_exec(pve_mgr, task.target_node,
+        rc_qt2, out_qt2, err_qt2 = _pve_node_exec(pve_mgr, task.target_node,
             f"timeout 10 qemu-img info "
             f"ssh://{esxi_user}@{esxi_host}{esxi_test_path} 2>&1",
-            timeout=20)
-        qt2_out = str(out_qt2 or '')
+            timeout=20, ignore_node_backoff=True)
+        qt2_out = (str(out_qt2 or '') + str(err_qt2 or '')).strip()
         if rc_qt2 == 0 and ('virtual size' in qt2_out or 'file format' in qt2_out):
             qemu_ssh_works = True
             task.log("QEMU SSH driver: connection OK (URL syntax)")
@@ -3786,12 +3786,12 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
             f"?dcPath=ha-datacenter&dsName={ds_name}"
         )
         
-        rc_ht, out_ht, _ = _pve_node_exec(pve_mgr, task.target_node,
+        rc_ht, out_ht, err_ht = _pve_node_exec(pve_mgr, task.target_node,
             f"timeout 10 qemu-img info --force-share "
             f"'json:{{\"file.driver\":\"https\",\"file.url\":\"{test_url}\","
             f"\"file.sslverify\":\"off\"}}' 2>&1",
-            timeout=15)
-        ht_out = str(out_ht or '')
+            timeout=15, ignore_node_backoff=True)
+        ht_out = (str(out_ht or '') + str(err_ht or '')).strip()
         
         if rc_ht == 0 and ('virtual size' in ht_out or 'file format' in ht_out):
             task.log("QEMU HTTPS driver: connection OK ✓")
@@ -3859,16 +3859,25 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
             flat_file = desc_file.replace('.vmdk', '-flat.vmdk')
             local_fuse_path = f"{mnt_path}/{vm_dir}/{flat_file}"
             
-            rc_chk, out_chk, _ = _pve_node_exec(pve_mgr, task.target_node,
-                f"test -f '{local_fuse_path}' && stat --format='%s' '{local_fuse_path}' 2>&1",
-                timeout=10)
-            chk_out = str(out_chk or '').strip()
+            rc_chk, out_chk, err_chk = _pve_node_exec(pve_mgr, task.target_node,
+                f"for i in 1 2 3 4 5 6 7 8 9 10; do "
+                f"test -f '{local_fuse_path}' && stat --format='%s' '{local_fuse_path}' && exit 0; "
+                f"sleep 1; "
+                f"done; "
+                f"echo NOTFOUND; "
+                f"echo '--- mount ---'; mount | grep '{mnt_path}' 2>&1 || true; "
+                f"echo '--- mnt_path ---'; ls -la '{mnt_path}' 2>&1 || true; "
+                f"echo '--- vm_dir ---'; ls -la '{mnt_path}/{vm_dir}' 2>&1 || true; "
+                f"echo '--- target_file ---'; ls -lh '{local_fuse_path}' 2>&1 || true; "
+                f"exit 1",
+                timeout=20, ignore_node_backoff=True)
+            chk_out = (str(out_chk or '') + str(err_chk or '')).strip()
             
             if rc_chk == 0 and chk_out.isdigit() and int(chk_out) > 0:
                 sshfs_flat_paths.append(local_fuse_path)
                 task.log(f"  SSHFS disk {di}: {local_fuse_path} ({int(chk_out) / (1024**3):.1f} GB)")
             else:
-                task.log(f"  SSHFS disk {di}: NOT accessible at {local_fuse_path}")
+                task.log(f"  SSHFS disk {di}: NOT accessible at {local_fuse_path}; debug: {chk_out[:1500]}")
                 sshfs_ok = False
                 break
         
@@ -3901,14 +3910,15 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
             # No boot: line needed -- args: -device bootindex=0 controls boot order
             
             # Test: can QEMU open the SSHFS file?
-            rc_ftest, out_ftest, _ = _pve_node_exec(pve_mgr, task.target_node,
-                f"timeout 10 qemu-img info '{sshfs_flat_paths[0]}' 2>&1", timeout=15)
-            ftest_out = str(out_ftest or '')
+            rc_ftest, out_ftest, err_ftest = _pve_node_exec(pve_mgr, task.target_node,
+                f"timeout 30 qemu-img info -f raw '{sshfs_flat_paths[0]}' 2>&1",
+                timeout=40, ignore_node_backoff=True)
+            ftest_out = (str(out_ftest or '') + str(err_ftest or '')).strip()
             if 'virtual size' in ftest_out or 'file format' in ftest_out:
                 sshfs_boot = True
                 task.log("SSHFS QEMU test: OK")
             else:
-                task.log(f"SSHFS QEMU test failed: {ftest_out[:150]}")
+                task.log(f"SSHFS QEMU test failed: {ftest_out[:1000]}")
     
     # ----------------------------------------------------------------
     # Fallback 2: NBD bridge (most robust -- bypasses AppArmor & FUSE)
@@ -3921,13 +3931,15 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
         task.log("SSHFS direct failed - trying NBD bridge...")
         
         # Check qemu-nbd is available
-        rc_nbd, _, _ = _pve_node_exec(pve_mgr, task.target_node,
-            "which qemu-nbd 2>/dev/null", timeout=5)
+        rc_nbd, out_nbd, err_nbd = _pve_node_exec(pve_mgr, task.target_node,
+            "command -v qemu-nbd 2>/dev/null", timeout=5,
+            ignore_node_backoff=True)
         
         if rc_nbd == 0:
             # Load nbd kernel module
             _pve_node_exec(pve_mgr, task.target_node,
-                "modprobe nbd max_part=0 2>/dev/null", timeout=5)
+                "modprobe nbd max_part=0 2>/dev/null", timeout=5,
+                ignore_node_backoff=True)
             
             nbd_ok = True
             nbd_args_parts = []
@@ -3938,17 +3950,19 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
                 
                 # Kill any leftover nbd on this socket
                 _pve_node_exec(pve_mgr, task.target_node,
-                    f"fuser -k {sock_path} 2>/dev/null; rm -f {sock_path}", timeout=5)
+                    f"fuser -k {sock_path} 2>/dev/null; rm -f {sock_path}", timeout=5,
+                    ignore_node_backoff=True)
                 
                 # Start qemu-nbd serving the flat VMDK via Unix socket
-                rc_ns, out_ns, _ = _pve_node_exec(pve_mgr, task.target_node,
+                rc_ns, out_ns, err_ns = _pve_node_exec(pve_mgr, task.target_node,
                     f"qemu-nbd --fork --persistent "
                     f"--socket={sock_path} "
                     f"--format=raw "
                     f"--cache=writeback "
                     f"--aio=threads "
-                    f"'{fuse_path}' 2>&1", timeout=15)
-                ns_out = str(out_ns or '')
+                    f"'{fuse_path}' 2>&1", timeout=15,
+                    ignore_node_backoff=True)
+                ns_out = (str(out_ns or '') + str(err_ns or '')).strip()
                 
                 if rc_ns != 0:
                     task.log(f"  NBD disk {di}: qemu-nbd failed: {ns_out[:150]}")
@@ -3957,10 +3971,12 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
                 
                 # Verify socket exists
                 time.sleep(1)
-                rc_sc, _, _ = _pve_node_exec(pve_mgr, task.target_node,
-                    f"test -S {sock_path}", timeout=5)
+                rc_sc, out_sc, err_sc = _pve_node_exec(pve_mgr, task.target_node,
+                    f"test -S {sock_path}", timeout=5,
+                    ignore_node_backoff=True)
                 if rc_sc != 0:
-                    task.log(f"  NBD disk {di}: socket not created at {sock_path}")
+                    sc_out = (str(out_sc or '') + str(err_sc or '')).strip()
+                    task.log(f"  NBD disk {di}: socket not created at {sock_path}: {sc_out[:150]}")
                     nbd_ok = False
                     break
                 
@@ -3994,7 +4010,8 @@ def _do_sshfs_boot_migration(pve_mgr, task, vmware_mgr, esxi_host, esxi_user, es
                 nbd_boot = True
                 task.log("NBD bridge ready - QEMU will connect via Unix sockets")
         else:
-            task.log("qemu-nbd not available")
+            nbd_out = (str(out_nbd or '') + str(err_nbd or '')).strip()
+            task.log(f"qemu-nbd not available: {nbd_out[:150]}")
     elif not qemu_ssh_works and not sshfs_boot and not sshfs_flat_paths:
         # SSHFS mount failed entirely -- try remounting
         task.log("SSHFS not available - trying to remount...")

--- a/pegaprox/utils/ssh.py
+++ b/pegaprox/utils/ssh.py
@@ -321,7 +321,8 @@ def _ssh_exec(host, user, password, cmd, timeout=30, use_controlmaster=False,
 
 _node_ip_cache = {}  # (cluster_id, node) -> (ip, timestamp)
 
-def _pve_node_exec(pve_mgr, node, cmd, timeout=600, use_controlmaster=True):
+def _pve_node_exec(pve_mgr, node, cmd, timeout=600, use_controlmaster=True,
+                   ignore_node_backoff=False):
     """Execute a command on a Proxmox node via the Proxmox API.
     Uses POST /nodes/{node}/execute or falls back to SSH.
 
@@ -335,14 +336,18 @@ def _pve_node_exec(pve_mgr, node, cmd, timeout=600, use_controlmaster=True):
     MK May 2026 (dead-node UI hang) — short-circuit if the per-node circuit
     breaker says this node is unreachable; register failure on SSH errors so
     repeated calls don't burn a full timeout every time."""
-    # MK — fail-fast if the breaker is open
-    try:
-        blocked, remaining = pve_mgr._is_node_blocked(node)
-        if blocked:
-            return 1, '', f"node '{node}' in circuit-breaker backoff ({remaining}s remaining)"
-    except Exception:
-        # Older managers without the breaker — proceed as before
-        pass
+    # MK — fail-fast if the breaker is open, unless the caller is already in a
+    # controlled workflow that needs to probe the node to recover from a stale
+    # breaker. V2P migration uses this for short local checks on the target node:
+    # a failed remote ESXi backend probe must not block SSHFS/NBD fallbacks.
+    if not ignore_node_backoff:
+        try:
+            blocked, remaining = pve_mgr._is_node_blocked(node)
+            if blocked:
+                return 1, '', f"node '{node}' in circuit-breaker backoff ({remaining}s remaining)"
+        except Exception:
+            # Older managers without the breaker — proceed as before
+            pass
 
     # Method 1: Try Proxmox API exec (PVE 7.4+)
     try:


### PR DESCRIPTION
## Summary

This PR fixes several V2P migration fallback issues around SSHFS/live mirror handling.

The main problem I ran into was that “Live Mirror / Near-Zero Downtime” could fail even when the ESXi datastore was mounted correctly over SSHFS and the flat VMDK was readable from the Proxmox target node. In my setup, PegaProx runs in a container and migrates to external Proxmox nodes. I am not expecting every fallback method, especially NBD, to work in all containerized setups without extra host/device passthrough, but the current fallback flow could still incorrectly give up even when SSHFS itself was usable.

## What this fixes

- Prevents stale Proxmox node circuit-breaker backoff from blocking short local checks during V2P fallback probing.
- Captures stderr for QEMU/SSHFS/NBD checks so migration logs show the real failure reason.
- Makes the SSHFS disk visibility check retry briefly before declaring the flat VMDK inaccessible.
- Adds useful debug output when the SSHFS path is not visible.
- Changes the SSHFS QEMU test to use `qemu-img info -f raw` for flat VMDK files.
- Makes NBD fallback logging more accurate when `qemu-nbd` exists but the check was blocked or failed for another reason.

## Background

During testing, SSHFS mounted the ESXi datastore successfully and the flat VMDK was visible on the target Proxmox node. Manual checks like this worked:

```bash
qemu-img info -f raw /tmp/v2p-.../vmname/vmname-flat.vmdk
```

However, the migration code could still fail the SSHFS QEMU test or report misleading fallback errors. In some cases the node circuit-breaker backoff message was returned during local target-node checks, which caused later fallback logic to fail immediately even though the target node was reachable and the disk file was readable.

## Scope

This is intended as a bugfix only. It does not add a new migration feature or change the UI. It only makes the existing fallback checks more reliable and the failure logs more useful.