### PR TITLE
fix: Re-allow private ip ranges for ACME

### DIFF
--- a/pegaprox/core/acme.py
+++ b/pegaprox/core/acme.py
@@ -10,6 +10,7 @@ import hashlib
 import base64
 import requests
 import secrets
+from urllib.parse import urlparse
 
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa, padding, utils
@@ -85,7 +86,7 @@ def _jws_header(account_key, url, nonce, kid=None):
     return header
 
 
-def _signed_request(url, payload, account_key, nonce, kid=None):
+def _signed_request(url, payload, account_key, nonce, kid=None, trusted_hosts=()):
     """Send a JWS-signed POST to an ACME endpoint"""
     header = _jws_header(account_key, url, nonce, kid)
     protected = _b64url(json.dumps(header))
@@ -104,24 +105,24 @@ def _signed_request(url, payload, account_key, nonce, kid=None):
         'payload': payload_b64,
         'signature': _b64url(signature),
     }
-    _guard_acme_url(url)
+    _guard_acme_url(url, trusted_hosts)
     resp = requests.post(url, json=body, headers={'Content-Type': 'application/jose+json'},
                          timeout=30, allow_redirects=False)
     return resp
 
 
-def _guard_acme_url(url):
+def _guard_acme_url(url, trusted_hosts):
     """M-8/M-9 (security audit): every ACME follow-on URL pulled out of the
     directory doc (newNonce/newAccount/newOrder/finalize/certificate/authz/
     challenge) must pass the SAME SSRF guard as the directory itself — a
     hostile/MITM'd directory response could point them at 169.254.169.254 /
     RFC1918. Public CAs (Let's Encrypt) are unaffected. Raises SsrfError."""
     from pegaprox.utils.url_security import sanitize_outbound_url
-    return sanitize_outbound_url(url)  # https-only + block-private (matches directory guard)
+    return sanitize_outbound_url(url, trusted_hosts=trusted_hosts)  # https-only + block-private (matches directory guard)
 
 
-def _get_nonce(directory):
-    _guard_acme_url(directory['newNonce'])
+def _get_nonce(directory, trusted_hosts=()):
+    _guard_acme_url(directory['newNonce'], trusted_hosts)
     resp = requests.head(directory['newNonce'], timeout=10, allow_redirects=False)
     return resp.headers['Replay-Nonce']
 
@@ -209,14 +210,14 @@ def _rfc2136_update(config, dns_name, dns_value, action='present'):
         return {'success': False, 'message': f'RFC 2136 DNS update failed: {e}'}
 
 
-def _validate_challenge(authz_url, challenge_url, account_key, nonce, kid, token=None):
+def _validate_challenge(authz_url, challenge_url, account_key, nonce, kid, token=None, trusted_hosts=()):
     """Notify ACME that the selected challenge is ready and poll authorization."""
-    ch_resp = _signed_request(challenge_url, {}, account_key, nonce, kid)
+    ch_resp = _signed_request(challenge_url, {}, account_key, nonce, kid, trusted_hosts=trusted_hosts)
     nonce = ch_resp.headers.get('Replay-Nonce', nonce)
 
     for attempt in range(30):
         time.sleep(2)
-        poll_resp = _signed_request(authz_url, None, account_key, nonce, kid)
+        poll_resp = _signed_request(authz_url, None, account_key, nonce, kid, trusted_hosts=trusted_hosts)
         nonce = poll_resp.headers.get('Replay-Nonce', nonce)
         authz_status = poll_resp.json()
 
@@ -238,7 +239,7 @@ def _validate_challenge(authz_url, challenge_url, account_key, nonce, kid, token
     return {'success': False, 'message': 'Challenge validation timed out (60s)'}
 
 
-def _finalize_order(domain, ssl_dir, order, order_url, account_key, nonce, kid):
+def _finalize_order(domain, ssl_dir, order, order_url, account_key, nonce, kid, trusted_hosts=()):
     """Generate the domain key/CSR, finalize the ACME order, and save cert files."""
     domain_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     csr = (
@@ -251,7 +252,7 @@ def _finalize_order(domain, ssl_dir, order, order_url, account_key, nonce, kid):
 
     finalize_url = order['finalize']
     fin_payload = {'csr': _b64url(csr_der)}
-    fin_resp = _signed_request(finalize_url, fin_payload, account_key, nonce, kid)
+    fin_resp = _signed_request(finalize_url, fin_payload, account_key, nonce, kid, trusted_hosts=trusted_hosts)
     nonce = fin_resp.headers.get('Replay-Nonce', nonce)
 
     if fin_resp.status_code not in (200, 201):
@@ -263,14 +264,14 @@ def _finalize_order(domain, ssl_dir, order, order_url, account_key, nonce, kid):
         if order_data.get('status') == 'valid' and order_data.get('certificate'):
             break
         time.sleep(2)
-        poll_resp = _signed_request(order_url, None, account_key, nonce, kid)
+        poll_resp = _signed_request(order_url, None, account_key, nonce, kid, trusted_hosts=trusted_hosts)
         nonce = poll_resp.headers.get('Replay-Nonce', nonce)
         order_data = poll_resp.json()
     else:
         return {'success': False, 'message': 'Timed out waiting for certificate'}
 
     cert_url = order_data['certificate']
-    cert_resp = _signed_request(cert_url, None, account_key, nonce, kid)
+    cert_resp = _signed_request(cert_url, None, account_key, nonce, kid, trusted_hosts=trusted_hosts)
     cert_pem = cert_resp.text
 
     os.makedirs(ssl_dir, exist_ok=True)
@@ -305,13 +306,14 @@ def _finalize_order(domain, ssl_dir, order, order_url, account_key, nonce, kid):
 def _create_order(domain, email, ssl_dir, staging=False, directory_url=None):
     """Create an ACME order and return the selected authorization context."""
     acme_url = _get_directory_url(staging=staging, directory_url=directory_url)
+    trusted_hosts = {urlparse(acme_url).hostname}
     account_key_path = os.path.join(ssl_dir, 'acme_account.key')
 
     env = 'custom' if (directory_url or '').strip() else ('staging' if staging else 'production')
     logging.info(f"[ACME] Starting certificate request for {domain} ({env}) via {acme_url}")
     try:
         from pegaprox.utils.url_security import sanitize_outbound_url, SsrfError
-        sanitize_outbound_url(acme_url)
+        sanitize_outbound_url(acme_url, trusted_hosts=trusted_hosts)
     except SsrfError as guard_err:
         return {'success': False, 'message': f'ACME directory URL rejected: {guard_err}'}
 
@@ -321,18 +323,18 @@ def _create_order(domain, email, ssl_dir, staging=False, directory_url=None):
 
     account_key = _load_or_create_account_key(account_key_path)
 
-    nonce = _get_nonce(directory)
+    nonce = _get_nonce(directory, trusted_hosts)
     reg_payload = {'termsOfServiceAgreed': True}
     if email:
         reg_payload['contact'] = [f'mailto:{email}']
 
-    reg_resp = _signed_request(directory['newAccount'], reg_payload, account_key, nonce)
+    reg_resp = _signed_request(directory['newAccount'], reg_payload, account_key, nonce, trusted_hosts=trusted_hosts)
     nonce = reg_resp.headers.get('Replay-Nonce', nonce)
     kid = reg_resp.headers['Location']
     logging.info(f"[ACME] Account registered/found: {kid}")
 
     order_payload = {'identifiers': [{'type': 'dns', 'value': domain}]}
-    order_resp = _signed_request(directory['newOrder'], order_payload, account_key, nonce, kid)
+    order_resp = _signed_request(directory['newOrder'], order_payload, account_key, nonce, kid, trusted_hosts=trusted_hosts)
     nonce = order_resp.headers.get('Replay-Nonce', nonce)
 
     if order_resp.status_code not in (200, 201):
@@ -341,7 +343,7 @@ def _create_order(domain, email, ssl_dir, staging=False, directory_url=None):
 
     order = order_resp.json()
     authz_url = order['authorizations'][0]
-    authz_resp = _signed_request(authz_url, None, account_key, nonce, kid)
+    authz_resp = _signed_request(authz_url, None, account_key, nonce, kid, trusted_hosts=trusted_hosts)
     nonce = authz_resp.headers.get('Replay-Nonce', nonce)
 
     return {
@@ -353,6 +355,7 @@ def _create_order(domain, email, ssl_dir, staging=False, directory_url=None):
         'order_url': order_resp.headers.get('Location', ''),
         'authz_url': authz_url,
         'authz': authz_resp.json(),
+        'trusted_hosts': trusted_hosts,
     }
 
 
@@ -402,13 +405,13 @@ def request_certificate(domain, email, ssl_dir, staging=False, directory_url=Non
         _pending_challenges[token] = key_authorization
         logging.info(f"[ACME] Challenge token set, waiting for validation...")
 
-        result = _validate_challenge(authz_url, http_challenge['url'], account_key, nonce, kid, token=token)
+        result = _validate_challenge(authz_url, http_challenge['url'], account_key, nonce, kid, token=token, trusted_hosts=context.get('trusted_hosts', ()))
         if not result.get('success'):
             return result
         nonce = result['nonce']
 
         _pending_challenges.pop(token, None)
-        return _finalize_order(domain, ssl_dir, order, order_url, account_key, nonce, kid)
+        return _finalize_order(domain, ssl_dir, order, order_url, account_key, nonce, kid, trusted_hosts=context.get('trusted_hosts', ()))
 
     except Exception as e:
         logging.error(f"[ACME] Certificate request failed: {e}")
@@ -612,3 +615,4 @@ def check_and_renew(domain, email, ssl_dir, staging=False, days_before=30, direc
     else:
         logging.error(f"[ACME] Renewal failed: {result['message']}")
         return False
+

--- a/pegaprox/utils/url_security.py
+++ b/pegaprox/utils/url_security.py
@@ -88,6 +88,7 @@ def is_safe_outbound_url(
     *,
     allowed_schemes: Iterable[str] = ('https',),
     allow_private: bool = False,
+    trusted_hosts: Iterable[str] = (),
     require_resolution: bool = True,
 ) -> Tuple[bool, str]:
     """Return (ok, reason).
@@ -106,6 +107,12 @@ def is_safe_outbound_url(
             we only reject IP-literal hosts that are obviously bad
             (faster, but vulnerable to DNS rebinding).
     """
+    trusted_hosts = {
+        h.strip().lower().strip("[]")
+        for h in trusted_hosts
+        if h
+    }
+
     if not isinstance(url, str) or not url:
         return False, 'empty url'
     # CR/LF/NUL anywhere in the URL → header smuggling vector
@@ -141,7 +148,11 @@ def is_safe_outbound_url(
     if ip_literal is not None:
         if str(ip_literal) in _METADATA_HOSTS:
             return False, f'IP {ip_literal} is metadata endpoint'
-        if not allow_private and _is_private_or_special(ip_literal):
+        if (
+            not allow_private
+            and _is_private_or_special(ip_literal)
+            and str(ip_literal) not in trusted_hosts
+        ):
             return False, f'IP {ip_literal} is private / loopback / metadata'
         return True, 'ok (ip literal)'
 
@@ -159,7 +170,12 @@ def is_safe_outbound_url(
     for ip in resolved:
         if str(ip) in _METADATA_HOSTS:
             return False, f'host {host!r} resolves to metadata IP {ip}'
-        if not allow_private and _is_private_or_special(ip):
+        if (
+            not allow_private
+            and _is_private_or_special(ip)
+            and host.lower() not in trusted_hosts
+            and str(ip) not in trusted_hosts
+        ):
             return False, f'host {host!r} resolves to private/loopback {ip}'
 
     return True, 'ok'


### PR DESCRIPTION
## **User description**
fix: Re-allow private ip ranges for ACME
  This patch is required to re-allow people using
  their own root CA instances (e.g., StepCA) on
  personal / private ip ranges. As a result, we
  define a new key for 'trusted_hosts' which is the
  given host from the ACME domain.

Note: Draft, needs to be tested furthermore.


___

## **CodeAnt-AI Description**
**Allow ACME certificates to work with trusted private servers**

### What Changed
- ACME requests now allow private or loopback addresses when they belong to the configured ACME server, so custom CAs on internal networks work again
- The ACME server’s host is treated as trusted for follow-up requests too, including account setup, challenge checks, order polling, and certificate download
- Other private or metadata addresses remain blocked, keeping outbound URL checks in place for untrusted destinations

### Impact
`✅ Internal ACME setups work again`
`✅ Fewer certificate request failures on private networks`
`✅ Safer outbound requests to untrusted addresses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
