### PR TITLE
fix(#419 follow-up): node Network In/Out freezes for 60s, take the rate from live counters

### DIFF
--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -407,6 +407,12 @@ class PegaProxManager:
         self._last_reconnect_attempt = 0  # NS: Feb 2026 - throttle reconnection attempts in broadcast loop
         self._consecutive_empty_responses = 0  # NS: Feb 2026 - detect stale tickets (connected but empty data)
 
+        # SP Jul 2026 (#419 follow-up) - live node network rate state, see
+        # _get_live_node_net_rates(). counters: node -> {ts, netin, netout, rate}
+        self._node_net_counters = {}
+        self._node_net_rates = {}   # node -> (netin_bps, netout_bps), last computed
+        self._node_net_fetched_at = 0.0  # time.monotonic() of last metrics/export pull
+
         # MK May 2026 (#444) — auth-circuit-breaker. surreal70 reported a DoS where
         # stale root creds made our workers spam /access/ticket until pveproxy
         # locked out everything (including the legit Proxmox web UI). Three
@@ -1246,7 +1252,87 @@ class PegaProxManager:
     def _get_api_url(self, path: str) -> str:
         host = self.host
         return f"https://{host}:{self.api_port}/api2/json{path}"
-    
+
+    # pvestatd broadcasts node counters every 10s, so polling faster than that
+    # is a wasted roundtrip. Half the interval still catches every sample.
+    _NODE_NET_MIN_INTERVAL = 5.0
+
+    def _get_live_node_net_rates(self) -> Dict[str, Any]:
+        """Live per-node network rate (bytes/sec), differentiated from counters.
+
+        SP Jul 2026 (#419 follow-up): /nodes/{name}/rrddata gives a rate, but the
+        'hour' timeframe has a 60s RRD step and PVE leaves the last 1-2 averaging
+        windows null, so the dashboard value is 60s-coarse AND 60-120s behind.
+
+        /cluster/metrics/export is the pvestatd feed behind the external metric
+        servers (pve-manager >= 8.2.5). One cluster-wide call returns
+        node/{name} net_in + net_out as `derive` - cumulative /proc/net/dev
+        byte counters over physical NICs only, the exact same source RRD stores -
+        refreshed every 10s. Differentiating two samples gives a ~10s-fresh rate.
+
+        Returns {node: (netin_bps, netout_bps)}. A node missing from the dict
+        means "no answer, fall back to rrddata": endpoint not there
+        (pve-manager < 8.2.5), token without Sys.Audit on /, or we have only
+        seen one counter sample so far (one counter is not a rate).
+        """
+        now = time.monotonic()
+        if now - self._node_net_fetched_at < self._NODE_NET_MIN_INTERVAL:
+            return self._node_net_rates
+
+        try:
+            resp = self._api_get(self._get_api_url('/cluster/metrics/export'))
+            self._node_net_fetched_at = now
+            if resp.status_code != 200:
+                # 403 = token lacks Sys.Audit on /, 404 = pve-manager < 8.2.5
+                self.logger.debug(f"metrics/export unavailable (HTTP {resp.status_code}), using rrddata")
+                return self._node_net_rates
+            # This endpoint returns an object, so over HTTP it is double-wrapped:
+            # {"data": {"data": [ {id, metric, value, timestamp, type}, ... ]}}.
+            # `pvesh` strips the outer layer, the API does not.
+            payload = resp.json().get('data') or {}
+            rows = payload.get('data') if isinstance(payload, dict) else payload
+            rows = rows or []
+        except Exception as e:
+            self._node_net_fetched_at = now
+            self.logger.debug(f"metrics/export failed ({e}), using rrddata")
+            return self._node_net_rates
+
+        samples = {}
+        for row in rows:
+            rid = row.get('id') or ''
+            if not rid.startswith('node/'):
+                continue
+            metric = row.get('metric')
+            if metric not in ('net_in', 'net_out'):
+                continue
+            s = samples.setdefault(rid[len('node/'):], {})
+            s[metric] = row.get('value')
+            s['ts'] = row.get('timestamp')
+
+        for name, s in samples.items():
+            ts, ni, no = s.get('ts'), s.get('net_in'), s.get('net_out')
+            if ts is None or ni is None or no is None:
+                continue
+            prev = self._node_net_counters.get(name)
+            if prev and ts > prev['ts']:
+                dt = ts - prev['ts']
+                # max(0, ...) covers the counter reset a node reboot brings:
+                # one 0 B/s sample, then it resyncs on the next window.
+                rate = (max(0.0, (ni - prev['netin']) / dt),
+                        max(0.0, (no - prev['netout']) / dt))
+            elif prev:
+                # Same pvestatd window as our last pull - we poll faster than
+                # 10s. Hold the last rate; recomputing over dt=0 flaps to zero.
+                rate = prev['rate']
+            else:
+                rate = None  # first sighting, nothing to differentiate against
+            self._node_net_counters[name] = {'ts': ts, 'netin': ni, 'netout': no, 'rate': rate}
+
+        self._node_net_rates = {
+            n: c['rate'] for n, c in self._node_net_counters.items() if c['rate'] is not None
+        }
+        return self._node_net_rates
+
     def get_node_status(self) -> Dict[str, Any]:
         # gets node status, calculates load score
         # MK: made this parallel, was super slow before
@@ -1330,12 +1416,19 @@ class PegaProxManager:
                 # rate (bytes/sec, AVERAGE over the timeframe step). Fold the
                 # RRD fetch into fetch_node_details() so it rides the same
                 # parallel pool as the status call and walls don't double.
+                # That RRD path is now the FALLBACK only — see
+                # _get_live_node_net_rates() for the live 10s source.
                 api_nodes = set()
+
+                # SP Jul 2026 (#419 follow-up): one cluster-wide call for live
+                # ~10s rates. Nodes it cannot answer for fall through to the
+                # per-node rrddata pull below, so nothing regresses.
+                live_net = self._get_live_node_net_rates()
 
                 def fetch_node_details(node):
                     node_name = node['node']
                     status_data = None
-                    netio = (0, 0)  # (netin, netout) bytes/sec, fall back to 0
+                    netio = live_net.get(node_name, (0, 0))  # (netin, netout) bytes/sec
 
                     # MK May 2026 — short-circuit nodes in breaker backoff so a
                     # dead node doesn't burn the full per-node timeout × every
@@ -1358,9 +1451,10 @@ class PegaProxManager:
                     except Exception:
                         self._register_node_failure(node_name)
 
-                    # RRD pull — only attempt if status came back (no point
+                    # RRD fallback — only when metrics/export gave us no live rate
+                    # for this node, and only if status came back (no point
                     # spending an HTTP roundtrip on a clearly-dead node).
-                    if status_data is not None:
+                    if status_data is not None and node_name not in live_net:
                         try:
                             rrd_url = f"https://{host}:{self.api_port}/api2/json/nodes/{node_name}/rrddata"
                             rr = sess.get(rrd_url, params={'timeframe': 'hour', 'cf': 'AVERAGE'}, timeout=self.per_node_timeout)
@@ -1458,8 +1552,9 @@ class PegaProxManager:
                         disk_total = rootfs.get('total', 1)
                         disk_percent = (disk_used / disk_total) * 100 if disk_total > 0 else 0
                         
-                        # Network stats — from /nodes/{name}/rrddata (rate, bytes/sec)
-                        # see fetch_node_details() above and #419 for the why.
+                        # Network stats — bytes/sec rate. Live (~10s) from
+                        # /cluster/metrics/export, else /nodes/{name}/rrddata (60s).
+                        # See fetch_node_details() above and #419 for the why.
                         netin, netout = netio
                         
                         # weighted scoring — configurable via balance_*_weight settings

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -1314,6 +1314,13 @@ class PegaProxManager:
                 metric = row.get('metric')
                 if metric not in ('net_in', 'net_out'):
                     continue
+                # Only differentiate a cumulative counter. If PVE ever reports
+                # net_in as a `gauge` (an already-computed rate), treating it as
+                # a counter would produce garbage. Tolerate the field being
+                # absent so a future rename degrades to rrddata, not nonsense.
+                rtype = row.get('type')
+                if rtype is not None and rtype != 'derive':
+                    continue
                 value, ts = row.get('value'), row.get('timestamp')
                 if not isinstance(value, (int, float)) or not isinstance(ts, (int, float)):
                     continue
@@ -1330,6 +1337,12 @@ class PegaProxManager:
                 if ts is None or ni is None or no is None:
                     continue
                 prev = self._node_net_counters.get(name)
+                if prev and ts < prev['ts']:
+                    # Out-of-order sample: a retried request landing late, or the
+                    # node's clock stepping back. Hold the rate and keep the
+                    # NEWER baseline - regressing it would make the next window
+                    # span a wrong interval and under-report the rate.
+                    continue
                 if prev and ts > prev['ts']:
                     dt = ts - prev['ts']
                     # max(0, ...) covers the counter reset a node reboot brings:

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -1324,6 +1324,11 @@ class PegaProxManager:
                 value, ts = row.get('value'), row.get('timestamp')
                 if not isinstance(value, (int, float)) or not isinstance(ts, (int, float)):
                     continue
+                # Last-wins per id+metric. Correct only because pvestatd emits ONE
+                # aggregated net_in/net_out per node (summed over physical NICs,
+                # pvestatd.pm via ip_link_is_physical). If PVE ever emitted a row
+                # per NIC, this would silently keep just the last one and
+                # under-report throughput - sum them here instead.
                 s = samples.setdefault(rid[len('node/'):], {})
                 s[metric] = value
                 s['ts'] = ts

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -412,6 +412,7 @@ class PegaProxManager:
         self._node_net_counters = {}
         self._node_net_rates = {}   # node -> (netin_bps, netout_bps), last computed
         self._node_net_fetched_at = 0.0  # time.monotonic() of last metrics/export pull
+        self._node_net_lock = threading.Lock()  # get_node_status() runs concurrently
 
         # MK May 2026 (#444) — auth-circuit-breaker. surreal70 reported a DoS where
         # stale root creds made our workers spam /access/ticket until pveproxy
@@ -1272,66 +1273,95 @@ class PegaProxManager:
 
         Returns {node: (netin_bps, netout_bps)}. A node missing from the dict
         means "no answer, fall back to rrddata": endpoint not there
-        (pve-manager < 8.2.5), token without Sys.Audit on /, or we have only
-        seen one counter sample so far (one counter is not a rate).
+        (pve-manager < 8.2.5), token without Sys.Audit on /, the endpoint is
+        failing, or we have only seen one counter sample so far (one counter is
+        not a rate). An empty dict must always mean "use rrddata" - never a
+        cached value, or a node freezes on a stale rate for as long as the
+        endpoint stays broken, which is worse than the 60s RRD step.
         """
         now = time.monotonic()
-        if now - self._node_net_fetched_at < self._NODE_NET_MIN_INTERVAL:
-            return self._node_net_rates
+        with self._node_net_lock:
+            if now - self._node_net_fetched_at < self._NODE_NET_MIN_INTERVAL:
+                return self._node_net_rates
+            # Claim the window BEFORE the request. _api_get yields to the gevent
+            # hub, so otherwise every concurrent get_node_status() caller (the
+            # SSE broadcast thread + one per open dashboard) sails past the
+            # throttle and fires its own cluster-wide fetch.
+            self._node_net_fetched_at = now
 
         try:
             resp = self._api_get(self._get_api_url('/cluster/metrics/export'))
-            self._node_net_fetched_at = now
             if resp.status_code != 200:
                 # 403 = token lacks Sys.Audit on /, 404 = pve-manager < 8.2.5
                 self.logger.debug(f"metrics/export unavailable (HTTP {resp.status_code}), using rrddata")
-                return self._node_net_rates
+                return self._drop_live_node_net_rates()
             # This endpoint returns an object, so over HTTP it is double-wrapped:
             # {"data": {"data": [ {id, metric, value, timestamp, type}, ... ]}}.
             # `pvesh` strips the outer layer, the API does not.
             payload = resp.json().get('data') or {}
             rows = payload.get('data') if isinstance(payload, dict) else payload
-            rows = rows or []
+
+            samples = {}
+            for row in rows or []:
+                # a shape surprise here used to raise straight through
+                # get_node_status() and lose every node's status, not just the
+                # net rates - so validate instead of trusting the payload
+                if not isinstance(row, dict):
+                    continue
+                rid = row.get('id') or ''
+                if not isinstance(rid, str) or not rid.startswith('node/'):
+                    continue
+                metric = row.get('metric')
+                if metric not in ('net_in', 'net_out'):
+                    continue
+                value, ts = row.get('value'), row.get('timestamp')
+                if not isinstance(value, (int, float)) or not isinstance(ts, (int, float)):
+                    continue
+                s = samples.setdefault(rid[len('node/'):], {})
+                s[metric] = value
+                s['ts'] = ts
         except Exception as e:
-            self._node_net_fetched_at = now
             self.logger.debug(f"metrics/export failed ({e}), using rrddata")
+            return self._drop_live_node_net_rates()
+
+        with self._node_net_lock:
+            for name, s in samples.items():
+                ts, ni, no = s.get('ts'), s.get('net_in'), s.get('net_out')
+                if ts is None or ni is None or no is None:
+                    continue
+                prev = self._node_net_counters.get(name)
+                if prev and ts > prev['ts']:
+                    dt = ts - prev['ts']
+                    # max(0, ...) covers the counter reset a node reboot brings:
+                    # one 0 B/s sample, then it resyncs on the next window.
+                    rate = (max(0.0, (ni - prev['netin']) / dt),
+                            max(0.0, (no - prev['netout']) / dt))
+                elif prev:
+                    # Same pvestatd window as our last pull - we poll faster than
+                    # 10s. Hold the last rate; recomputing over dt=0 flaps to zero.
+                    rate = prev['rate']
+                else:
+                    rate = None  # first sighting, nothing to differentiate against
+                self._node_net_counters[name] = {'ts': ts, 'netin': ni, 'netout': no, 'rate': rate}
+
+            # Built from THIS response only. A node that drops out of the feed
+            # has to fall back to rrddata, not keep serving its last known rate.
+            self._node_net_rates = {
+                n: self._node_net_counters[n]['rate'] for n in samples
+                if self._node_net_counters.get(n, {}).get('rate') is not None
+            }
             return self._node_net_rates
 
-        samples = {}
-        for row in rows:
-            rid = row.get('id') or ''
-            if not rid.startswith('node/'):
-                continue
-            metric = row.get('metric')
-            if metric not in ('net_in', 'net_out'):
-                continue
-            s = samples.setdefault(rid[len('node/'):], {})
-            s[metric] = row.get('value')
-            s['ts'] = row.get('timestamp')
+    def _drop_live_node_net_rates(self) -> Dict[str, Any]:
+        """Forget the live rates so callers fall back to rrddata.
 
-        for name, s in samples.items():
-            ts, ni, no = s.get('ts'), s.get('net_in'), s.get('net_out')
-            if ts is None or ni is None or no is None:
-                continue
-            prev = self._node_net_counters.get(name)
-            if prev and ts > prev['ts']:
-                dt = ts - prev['ts']
-                # max(0, ...) covers the counter reset a node reboot brings:
-                # one 0 B/s sample, then it resyncs on the next window.
-                rate = (max(0.0, (ni - prev['netin']) / dt),
-                        max(0.0, (no - prev['netout']) / dt))
-            elif prev:
-                # Same pvestatd window as our last pull - we poll faster than
-                # 10s. Hold the last rate; recomputing over dt=0 flaps to zero.
-                rate = prev['rate']
-            else:
-                rate = None  # first sighting, nothing to differentiate against
-            self._node_net_counters[name] = {'ts': ts, 'netin': ni, 'netout': no, 'rate': rate}
-
-        self._node_net_rates = {
-            n: c['rate'] for n, c in self._node_net_counters.items() if c['rate'] is not None
-        }
-        return self._node_net_rates
+        Counter history is kept: once the endpoint answers again, the next
+        sample differentiates against it over the longer gap, which is still a
+        valid average for a cumulative counter.
+        """
+        with self._node_net_lock:
+            self._node_net_rates = {}
+        return {}
 
     def get_node_status(self) -> Dict[str, Any]:
         # gets node status, calculates load score

--- a/tests/test_node_net_rates.py
+++ b/tests/test_node_net_rates.py
@@ -59,6 +59,24 @@ class _Resp:
         return {'data': {'data': self._rows}}
 
 
+class _RawResp:
+    """Arbitrary JSON body, for payload shapes _Resp cannot express.
+
+    Pass an Exception instance to make .json() itself blow up, which is what a
+    truncated or HTML error body does.
+    """
+
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
 def _rows(ts, netin, netout, node='pve1', extra=True):
     rows = [
         {'id': f'node/{node}', 'metric': 'net_in', 'value': netin, 'type': 'derive', 'timestamp': ts},
@@ -168,6 +186,77 @@ def test_malformed_rows_are_skipped_not_raised():
     assert rates['pve1'][0] == pytest.approx(10 * MB)
 
 
+@pytest.mark.parametrize('payload', [
+    {},                                     # no envelope at all
+    {'data': None},
+    {'data': 'oops'},                       # str - iterating it yields characters
+    {'data': 42},                           # not iterable at all
+    {'data': {}},                           # envelope, no rows
+    {'data': {'data': None}},
+    {'data': {'data': 'oops'}},
+    {'data': {'data': {'node/pve1': 5}}},   # dict - iterating it yields keys, not rows
+    ValueError('Expecting value: line 1 column 1'),   # body was not JSON
+])
+def test_malformed_payload_container_falls_back_instead_of_raising(payload):
+    # HTTP 200 with a body we cannot parse. The row loop lives outside the
+    # per-row try/except of the old cut, so a container surprise here raised
+    # through get_node_status() and lost EVERY node's status. It has to look
+    # exactly like "no live answer": empty dict, caller uses rrddata.
+    m = _mgr()
+    assert _feed(m, _RawResp(payload)) == {}
+
+
+def test_malformed_container_does_not_wipe_the_counter_history():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
+    assert _feed(m, _RawResp({'data': {'data': 'oops'}})) == {}
+    # counters survive a bad response, so the next good sample differentiates
+    # over the longer gap - a cumulative counter makes that a valid average
+    rates = _feed(m, _Resp(_rows(1020, 300 * MB, 300 * MB)))
+    assert rates['pve1'][0] == pytest.approx(10 * MB)   # 200 MB over 20s
+
+
+def test_half_a_node_pair_never_produces_a_rate():
+    # net_out missing (row dropped, or a partial pvestatd broadcast). Half a
+    # pair must not be stored, otherwise the next full sample differentiates
+    # net_out against a counter we never saw.
+    m = _mgr()
+    half = [{'id': 'node/pve1', 'metric': 'net_in', 'value': 100 * MB,
+             'type': 'derive', 'timestamp': 1000}]
+    assert _feed(m, _Resp(half)) == {}
+    assert 'pve1' not in m._node_net_counters
+    # so the first complete pair is a first sighting, not a rate
+    assert _feed(m, _Resp(_rows(1010, 200 * MB, 200 * MB))) == {}
+    assert _feed(m, _Resp(_rows(1020, 300 * MB, 300 * MB)))['pve1'][0] == pytest.approx(10 * MB)
+
+
+def test_a_node_reporting_only_gauge_rows_stays_on_rrddata():
+    # never-seen node whose net_in/net_out arrive as `gauge` - already a rate.
+    # Two of those must not become counter state and must not be differentiated,
+    # or the dashboard shows a number derived from two rates.
+    m = _mgr()
+    gauge = [
+        {'id': 'node/pve2', 'metric': 'net_in', 'value': 5 * MB, 'type': 'gauge', 'timestamp': 1000},
+        {'id': 'node/pve2', 'metric': 'net_out', 'value': 5 * MB, 'type': 'gauge', 'timestamp': 1000},
+    ]
+    assert _feed(m, _Resp(gauge)) == {}
+    assert 'pve2' not in m._node_net_counters
+    assert _feed(m, _Resp([dict(r, timestamp=1010, value=9 * MB) for r in gauge])) == {}
+    assert 'pve2' not in m._node_net_counters
+
+
+def test_two_nodes_keep_independent_counter_state():
+    # state is per node, including the timestamp - a single shared `ts` would
+    # divide one node's delta by the other node's interval
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)
+                   + _rows(1000, 500 * MB, 500 * MB, node='pve2', extra=False)))
+    rates = _feed(m, _Resp(_rows(1010, 200 * MB, 200 * MB)
+                           + _rows(1015, 650 * MB, 650 * MB, node='pve2', extra=False)))
+    assert rates['pve1'][0] == pytest.approx(10 * MB)          # 100 MB over 10s
+    assert rates['pve2'][0] == pytest.approx(150 * MB / 15)    # 150 MB over its own 15s
+
+
 def test_gauge_rows_never_get_treated_as_a_counter():
     # A `gauge` net_in would be an already-computed rate. Differentiating it
     # produces garbage, so it must not land in the counter state - not even when
@@ -233,6 +322,24 @@ def test_transport_failure_does_not_raise():
 
     m._api_get = boom
     assert m._get_live_node_net_rates() == {}
+
+
+def test_transport_failure_keeps_counter_history_for_the_next_good_sample():
+    # _drop_live_node_net_rates() forgets the RATES so callers fall back, but it
+    # must keep the counters. Forgetting those too costs an extra poll cycle with
+    # no live rate every time the endpoint hiccups.
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
+
+    def boom(url, **kw):
+        raise RuntimeError('connection reset')
+
+    m._node_net_fetched_at = 0.0
+    m._api_get = boom
+    assert m._get_live_node_net_rates() == {}
+
+    rates = _feed(m, _Resp(_rows(1030, 400 * MB, 400 * MB)))
+    assert rates['pve1'][0] == pytest.approx(10 * MB)   # 300 MB over 30s
 
 
 def test_throttle_skips_refetch_within_the_window():

--- a/tests/test_node_net_rates.py
+++ b/tests/test_node_net_rates.py
@@ -16,6 +16,9 @@
 #
 # No network here: the method is driven with a stubbed _api_get.
 
+import logging
+import threading
+
 import pytest
 
 from pegaprox.core.manager import PegaProxManager
@@ -29,7 +32,8 @@ def _mgr():
     m._node_net_counters = {}
     m._node_net_rates = {}
     m._node_net_fetched_at = 0.0
-    m.logger = __import__('logging').getLogger('test')
+    m._node_net_lock = threading.Lock()
+    m.logger = logging.getLogger('test')
     m._get_api_url = lambda path: 'https://stub' + path
     return m
 
@@ -119,14 +123,66 @@ def test_guest_and_non_net_rows_are_ignored():
     assert list(rates) == ['pve1']
 
 
-def test_endpoint_unavailable_keeps_last_known_rates():
+def test_endpoint_unavailable_falls_back_instead_of_serving_a_stale_rate():
+    # An earlier cut of this returned the cached rates here. get_node_status()
+    # gates its rrddata fallback on `node not in live_net`, so a cached entry
+    # suppressed the fallback and the node froze on its last known rate for as
+    # long as the endpoint stayed broken - worse than the 60s RRD step this
+    # whole change is about. Empty dict must mean "use rrddata".
+    for code in (403, 404, 500):
+        m = _mgr()
+        _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
+        assert _feed(m, _Resp(_rows(1010, 200 * MB, 200 * MB)))['pve1'][0] == pytest.approx(10 * MB)
+        assert _feed(m, _Resp([], status_code=code)) == {}
+
+
+def test_failure_also_clears_the_throttle_window_cache():
     m = _mgr()
     _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
     _feed(m, _Resp(_rows(1010, 200 * MB, 200 * MB)))
-    # pve-manager < 8.2.5 (404) or token without Sys.Audit on / (403)
-    for code in (403, 404, 500):
-        rates = _feed(m, _Resp([], status_code=code))
-        assert rates['pve1'][0] == pytest.approx(10 * MB)
+    assert _feed(m, _Resp([], status_code=403)) == {}
+    # a caller arriving inside the 5s throttle window must not get the pre-failure
+    # rate back out of the cache
+    assert m._get_live_node_net_rates() == {}
+
+
+def test_node_dropping_out_of_the_feed_loses_its_live_rate():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
+    assert 'pve1' in _feed(m, _Resp(_rows(1010, 200 * MB, 200 * MB)))
+    # node gone from the response (offline, or not in --node-list): it must fall
+    # back to rrddata rather than keep serving the rate we last computed
+    assert _feed(m, _Resp(_rows(1020, 1 * MB, 1 * MB, node='pve2'))) == {}
+
+
+def test_malformed_rows_are_skipped_not_raised():
+    # This used to be outside the try/except, so an AttributeError propagated
+    # through get_node_status() and lost EVERY node's status, not just net rates.
+    m = _mgr()
+    junk = ['a string', None, 42, {'id': None}, {'id': 'node/pve1'},
+            {'id': 'node/pve1', 'metric': 'net_in', 'value': 'not-a-number', 'timestamp': 1000},
+            {'id': 'node/pve1', 'metric': 'net_in', 'value': 1 * MB, 'timestamp': 'not-a-ts'}]
+    assert _feed(m, _Resp(junk)) == {}
+    assert _feed(m, _Resp(junk + _rows(1000, 100 * MB, 100 * MB))) == {}
+    rates = _feed(m, _Resp(junk + _rows(1010, 200 * MB, 200 * MB)))
+    assert rates['pve1'][0] == pytest.approx(10 * MB)
+
+
+def test_concurrent_callers_do_not_stampede_the_endpoint():
+    # _api_get yields to the gevent hub, so a second caller can arrive mid-fetch.
+    # The throttle window is claimed before the request precisely so that caller
+    # returns the cache instead of firing its own cluster-wide pull.
+    m = _mgr()
+    calls = []
+
+    def reentrant(url, **kw):
+        calls.append(url)
+        assert m._get_live_node_net_rates() == {}   # sees the claimed window
+        return _Resp(_rows(1000, 100 * MB, 100 * MB))
+
+    m._api_get = reentrant
+    m._get_live_node_net_rates()
+    assert len(calls) == 1
 
 
 def test_flat_payload_shape_is_tolerated():

--- a/tests/test_node_net_rates.py
+++ b/tests/test_node_net_rates.py
@@ -168,6 +168,37 @@ def test_malformed_rows_are_skipped_not_raised():
     assert rates['pve1'][0] == pytest.approx(10 * MB)
 
 
+def test_gauge_rows_never_get_treated_as_a_counter():
+    # A `gauge` net_in would be an already-computed rate. Differentiating it
+    # produces garbage, so it must not land in the counter state - not even when
+    # it arrives after a valid derive row for the same node.
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
+    poisoned = _rows(1010, 200 * MB, 200 * MB) + [
+        {'id': 'node/pve1', 'metric': 'net_in', 'value': 7, 'type': 'gauge', 'timestamp': 1010},
+        {'id': 'node/pve1', 'metric': 'net_out', 'value': 7, 'type': 'gauge', 'timestamp': 1010},
+    ]
+    rates = _feed(m, _Resp(poisoned))
+    assert rates['pve1'][0] == pytest.approx(10 * MB)   # not 7, not derived from 7
+    assert m._node_net_counters['pve1']['netin'] == 200 * MB
+    # and a row with no `type` at all is still accepted (future-proofing)
+    untyped = [{k: v for k, v in r.items() if k != 'type'} for r in _rows(1020, 300 * MB, 300 * MB)]
+    assert _feed(m, _Resp(untyped))['pve1'][0] == pytest.approx(10 * MB)
+
+
+def test_out_of_order_sample_does_not_regress_the_baseline():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
+    _feed(m, _Resp(_rows(1020, 300 * MB, 300 * MB)))     # 200 MB / 20s = 10 MB/s
+    # a stale response lands late (retry, or the node's clock stepped back)
+    held = _feed(m, _Resp(_rows(1005, 150 * MB, 150 * MB)))
+    assert held['pve1'][0] == pytest.approx(10 * MB)      # rate held, not recomputed
+    assert m._node_net_counters['pve1']['ts'] == 1020     # baseline NOT regressed
+    # next real sample differentiates against 1020, not against the stale 1005
+    nxt = _feed(m, _Resp(_rows(1030, 400 * MB, 400 * MB)))
+    assert nxt['pve1'][0] == pytest.approx(10 * MB)       # 100 MB / 10s
+
+
 def test_concurrent_callers_do_not_stampede_the_endpoint():
     # _api_get yields to the gevent hub, so a second caller can arrive mid-fetch.
     # The throttle window is claimed before the request precisely so that caller

--- a/tests/test_node_net_rates.py
+++ b/tests/test_node_net_rates.py
@@ -1,0 +1,165 @@
+# Live node network-rate state machine — PegaProxManager._get_live_node_net_rates().
+#
+# SP Jul 2026 (#419 follow-up) — node netin/netout used to come from
+# /nodes/{name}/rrddata, which has a 60s RRD step and leaves the last 1-2
+# averaging windows null, so the dashboard number froze for a minute at a time
+# and was 60-120s behind. The live source is /cluster/metrics/export: cumulative
+# (`derive`) net_in/net_out per node, refreshed by pvestatd every 10s. Turning a
+# counter into a rate needs two samples and has four cases that all misbehave in
+# a different way if you get them wrong:
+#
+#   1. one sample only          -> no rate yet, caller must fall back to rrddata
+#   2. timestamp advanced       -> differentiate over PVE's own timestamps
+#   3. timestamp unchanged      -> hold the last rate (we poll faster than 10s;
+#                                  dividing by dt=0 or returning 0 makes the UI flap)
+#   4. counter went backwards   -> node rebooted, clamp to 0 instead of negative
+#
+# No network here: the method is driven with a stubbed _api_get.
+
+import pytest
+
+from pegaprox.core.manager import PegaProxManager
+
+MB = 1048576
+
+
+def _mgr():
+    """Bare manager with only the attributes _get_live_node_net_rates touches."""
+    m = PegaProxManager.__new__(PegaProxManager)
+    m._node_net_counters = {}
+    m._node_net_rates = {}
+    m._node_net_fetched_at = 0.0
+    m.logger = __import__('logging').getLogger('test')
+    m._get_api_url = lambda path: 'https://stub' + path
+    return m
+
+
+class _Resp:
+    """Real /cluster/metrics/export HTTP shape.
+
+    This endpoint returns an object, so the API's own {"data": ...} envelope
+    makes it double-wrapped: {"data": {"data": [ ...rows... ]}}. `pvesh` strips
+    the outer layer, which is exactly how the first cut of this patch shipped a
+    stub that passed while the live code raised
+    "'str' object has no attribute 'get'" (iterating a dict yields its keys).
+    """
+
+    def __init__(self, rows, status_code=200, flat=False):
+        self.status_code = status_code
+        self._rows = rows
+        self._flat = flat
+
+    def json(self):
+        if self._flat:
+            return {'data': self._rows}   # tolerated shape, not what PVE sends
+        return {'data': {'data': self._rows}}
+
+
+def _rows(ts, netin, netout, node='pve1', extra=True):
+    rows = [
+        {'id': f'node/{node}', 'metric': 'net_in', 'value': netin, 'type': 'derive', 'timestamp': ts},
+        {'id': f'node/{node}', 'metric': 'net_out', 'value': netout, 'type': 'derive', 'timestamp': ts},
+    ]
+    if extra:
+        # guest rows and other node metrics share the response — must be ignored
+        rows += [
+            {'id': 'qemu/100', 'metric': 'net_in', 'value': 999 * MB, 'type': 'derive', 'timestamp': ts},
+            {'id': f'node/{node}', 'metric': 'cpu_current', 'value': 0.5, 'type': 'gauge', 'timestamp': ts},
+        ]
+    return rows
+
+
+def _feed(m, resp):
+    """One poll. Clears the 5s throttle so each call really fetches."""
+    m._node_net_fetched_at = 0.0
+    m._api_get = lambda url, **kw: resp
+    return m._get_live_node_net_rates()
+
+
+def test_first_sample_yields_no_rate():
+    m = _mgr()
+    assert _feed(m, _Resp(_rows(1000, 10 * MB, 5 * MB))) == {}
+    # counter is remembered so the next poll can differentiate
+    assert m._node_net_counters['pve1']['ts'] == 1000
+
+
+def test_second_sample_gives_bytes_per_second():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 50 * MB)))
+    rates = _feed(m, _Resp(_rows(1010, 200 * MB, 100 * MB)))
+    netin, netout = rates['pve1']
+    assert netin == pytest.approx(10 * MB)   # 100 MB over 10s
+    assert netout == pytest.approx(5 * MB)
+
+
+def test_same_timestamp_holds_last_rate_instead_of_flapping():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 50 * MB)))
+    _feed(m, _Resp(_rows(1010, 200 * MB, 100 * MB)))
+    # pvestatd has not broadcast a new window yet — same ts, same counters
+    held = _feed(m, _Resp(_rows(1010, 200 * MB, 100 * MB)))
+    assert held['pve1'][0] == pytest.approx(10 * MB)
+
+
+def test_counter_reset_clamps_to_zero():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 500 * MB, 500 * MB)))
+    # node rebooted: /proc/net/dev counters restart from ~0
+    rates = _feed(m, _Resp(_rows(1010, 1 * MB, 1 * MB)))
+    assert rates['pve1'] == (0.0, 0.0)
+    # and it resyncs on the following window
+    after = _feed(m, _Resp(_rows(1020, 21 * MB, 11 * MB)))
+    assert after['pve1'][0] == pytest.approx(2 * MB)
+
+
+def test_guest_and_non_net_rows_are_ignored():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 10 * MB, 10 * MB)))
+    rates = _feed(m, _Resp(_rows(1010, 20 * MB, 20 * MB)))
+    assert list(rates) == ['pve1']
+
+
+def test_endpoint_unavailable_keeps_last_known_rates():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
+    _feed(m, _Resp(_rows(1010, 200 * MB, 200 * MB)))
+    # pve-manager < 8.2.5 (404) or token without Sys.Audit on / (403)
+    for code in (403, 404, 500):
+        rates = _feed(m, _Resp([], status_code=code))
+        assert rates['pve1'][0] == pytest.approx(10 * MB)
+
+
+def test_flat_payload_shape_is_tolerated():
+    # defensive: if a future PVE version drops the inner envelope, still parse
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB), flat=True))
+    rates = _feed(m, _Resp(_rows(1010, 200 * MB, 100 * MB), flat=True))
+    assert rates['pve1'][0] == pytest.approx(10 * MB)
+
+
+def test_transport_failure_does_not_raise():
+    m = _mgr()
+    m._node_net_fetched_at = 0.0
+
+    def boom(url, **kw):
+        raise RuntimeError('connection reset')
+
+    m._api_get = boom
+    assert m._get_live_node_net_rates() == {}
+
+
+def test_throttle_skips_refetch_within_the_window():
+    m = _mgr()
+    _feed(m, _Resp(_rows(1000, 100 * MB, 100 * MB)))
+    _feed(m, _Resp(_rows(1010, 200 * MB, 200 * MB)))
+    calls = []
+
+    def counting(url, **kw):
+        calls.append(url)
+        return _Resp(_rows(1020, 400 * MB, 400 * MB))
+
+    m._api_get = counting
+    # no _node_net_fetched_at reset here — the 5s throttle must hold
+    rates = m._get_live_node_net_rates()
+    assert calls == []
+    assert rates['pve1'][0] == pytest.approx(10 * MB)


### PR DESCRIPTION
## **User description**
Closes #631.

## What's wrong

#419 fixed "node Network In/Out always 0" by moving to
`/nodes/{name}/rrddata?timeframe=hour&cf=AVERAGE`. That returns a real number,
but it can only ever be a 60-second average: the `hour` timeframe has a 60s RRD
step. On top of that, `fetch_node_details()` reverse-walks past the last 1-2
samples because PVE leaves them null while averaging. So the dashboard value is
60s-coarse AND 60-120s behind.

Measured on a live PVE 9.1.11 cluster via `/api/clusters/<id>/metrics`, 3s polls:

```
11:45:51  node1 in=8.85 out=5.90
11:46:07  node1 in=7.88 out=4.90   <- held for the next 57 seconds
11:47:04  node1 in=8.81 out=6.15
```

CPU/RAM/load come from `/nodes/{name}/status` and move on every poll, so only the
two network figures look frozen. `NodeCard`'s sparkline keeps 20 points at 2s
polls = 40s, shorter than one RRD step, so it draws a flat line.

## The live source

`/cluster/metrics/export` (pve-manager >= 8.2.5) is the pvestatd feed behind the
external metric servers. One cluster-wide call returns `node/{name}` `net_in` and
`net_out` as `derive` - the cumulative `/proc/net/dev` byte counters, summed over
physical NICs only (`pvestatd.pm`, `ip_link_is_physical`). That is the exact same
source RRD stores, rebroadcast every 10s:

```
ts=1785317884 gap=9s  rate=10.25 MB/s
ts=1785317894 gap=10s rate=10.09 MB/s
ts=1785317904 gap=10s rate=10.43 MB/s
```

Cost goes down, not up - one call for the whole cluster instead of one per node:

```
/nodes/{n}/rrddata      27.7 KB per node per refresh
/cluster/metrics/export 24.3 KB total, all nodes
```

## The fix

`_get_live_node_net_rates()` - one call per refresh (throttled to 5s, half the
pvestatd interval), differentiate two counter samples over PVE's own timestamps,
hand `fetch_node_details()` a ready rate. Four state cases:

- one sample only -> no rate yet, fall through to rrddata
- timestamp advanced -> differentiate
- timestamp unchanged -> hold the last rate. We poll faster than 10s, so most
  polls land in the same pvestatd window. Returning 0 here makes the UI flap.
- counter went backwards (node rebooted) -> clamp to 0, resync next window

Nothing regresses: a node absent from the returned dict falls through to the
existing rrddata pull. That covers 403 (token without `Sys.Audit` on `/`), 404
(pve-manager < 8.2.5) and the first poll after start.

Frontend is untouched - `NodeCard` already treats `metrics.netin` as a rate
since #435.

Watch out for one thing if you review the parsing: this endpoint returns an
object, so over HTTP it is double-wrapped `{"data": {"data": [...]}}`, while
`pvesh get` strips the outer envelope. Parsing it the way `pvesh` shows it
raises `'str' object has no attribute 'get'`, since iterating a dict yields keys.

## Test plan

- [x] `tests/test_node_net_rates.py` - 9 cases: the four state transitions, both
  payload shapes, non-200 (403/404/500), transport failure, throttle
- [x] Full suite: `286 passed`
- [x] Deployed on a live PVE 9.1.11 cluster, service restarted, no errors.
  First verified on 0.9.10.3 (backport), then the host was upgraded to **0.9.15**
  and this branch's `manager.py` was deployed byte-identical (`2a8dd157...`) - so
  the numbers below are from the exact code in this PR, on current `main`
- [x] Change cadence 57s -> 6-13s
- [x] Cross-checked against an independent 24s counter delta:

```
reported  node1 in=3.20-4.21  out=1.32-3.24   node2 in=0.08-0.25  out=0.12-0.30
measured  node1 in=3.57       out=2.28        node2 in=0.12       out=0.20
```

## Note

`PVEManager` in the #419 body is a typo for `PegaProxManager` - no such class.


___

## **CodeAnt-AI Description**
Refresh node network rates from live counters instead of delayed averages

### What Changed
- Node Network In/Out values now use live cluster counters, producing rates from roughly the latest 10-second window instead of relying on 60-second averages.
- The previous per-node average remains available automatically when live metrics are unavailable, unsupported, incomplete, or still awaiting a second sample.
- Repeated samples keep the last rate, counter resets never show negative traffic, and delayed or malformed responses do not disrupt node status.
- Added coverage for fallback behavior, malformed responses, concurrent polling, multiple nodes, and counter edge cases.

### Impact
`✅ Fresher node network rates`
`✅ Fewer frozen Network In/Out values`
`✅ Reliable status when live metrics are unavailable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
