### PR TITLE
fix(#633): TLS bootstrap fails closed instead of serving plaintext on the TLS port

### DIFF
--- a/pegaprox/app.py
+++ b/pegaprox/app.py
@@ -637,11 +637,11 @@ def _path_diagnostics(path):
     for p in (target, os.path.dirname(target)):
         try:
             st = os.stat(p)
-            lines.append("  %s owner=%s:%s mode=%s" % (
+            lines.append("  %s owner=%s:%s mode=0o%03o" % (
                 p,
                 _name(pwd and pwd.getpwuid, 'pw_name', st.st_uid),
                 _name(grp and grp.getgrgid, 'gr_name', st.st_gid),
-                oct(stat.S_IMODE(st.st_mode))))
+                stat.S_IMODE(st.st_mode)))
         except OSError as e:
             lines.append("  %s cannot stat: %s" % (p, e.strerror))
     lines.append("  this process uid=%s(%s) gid=%s(%s)" % (

--- a/pegaprox/app.py
+++ b/pegaprox/app.py
@@ -7,6 +7,8 @@ Creates and configures the Flask application.
 import os
 import sys
 import time
+import errno
+import stat
 import logging
 import threading
 import signal
@@ -610,6 +612,141 @@ export * from '/static/js/novnc/core/rfb.js';
     return failed == 0
 
 
+def _path_diagnostics(path):
+    """owner/mode of a path and of its parent, plus who we are.
+
+    #633: the operator needs to compare the two. The whole bug was a cert the
+    service user could not reach, and the log said nothing about who owned it.
+    """
+    try:
+        import pwd
+        import grp
+    except ImportError:      # non-POSIX, ids only
+        pwd = grp = None
+
+    def _name(getter, attr, num):
+        if getter is None:
+            return str(num)
+        try:
+            return getattr(getter(num), attr)
+        except (KeyError, OSError):
+            return str(num)
+
+    lines = []
+    target = os.path.abspath(path)
+    for p in (target, os.path.dirname(target)):
+        try:
+            st = os.stat(p)
+            lines.append("  %s owner=%s:%s mode=%s" % (
+                p,
+                _name(pwd and pwd.getpwuid, 'pw_name', st.st_uid),
+                _name(grp and grp.getgrgid, 'gr_name', st.st_gid),
+                oct(stat.S_IMODE(st.st_mode))))
+        except OSError as e:
+            lines.append("  %s cannot stat: %s" % (p, e.strerror))
+    lines.append("  this process uid=%s(%s) gid=%s(%s)" % (
+        os.geteuid(), _name(pwd and pwd.getpwuid, 'pw_name', os.geteuid()),
+        os.getegid(), _name(grp and grp.getgrgid, 'gr_name', os.getegid())))
+    return "\n".join(lines)
+
+
+def _tls_setup_failed(reason, path):
+    """Fail closed, or return None if plaintext was asked for explicitly.
+
+    #633: this used to print a WARNING and fall through with ssl_context=None,
+    which bound cleartext HTTP on the port that was meant to be TLS. TLS clients
+    then got "Invalid http version: '\\x16\\x03\\x01...'" and the dashboard was
+    down while the service looked healthy. A downgrade has to be a decision, not
+    an accident.
+    """
+    detail = "TLS is enabled but there is no usable certificate: %s\n%s" % (
+        reason, _path_diagnostics(path))
+    if os.environ.get('PEGAPROX_ALLOW_PLAINTEXT', '').strip().lower() in ('1', 'true', 'yes', 'on'):
+        logging.getLogger(__name__).error(
+            "%s\n  PEGAPROX_ALLOW_PLAINTEXT is set, so serving PLAINTEXT HTTP on the "
+            "TLS port anyway - every TLS client will fail against it.", detail)
+        return None
+    raise SystemExit(
+        "%s\n  Refusing to serve plaintext on the TLS port. Fix the certificate, or put "
+        "PegaProx behind a reverse proxy (the reverse_proxy setting), or set "
+        "PEGAPROX_ALLOW_PLAINTEXT=1 to serve cleartext there on purpose." % detail)
+
+
+def _unreadable(path):
+    """The OSError from opening path, or None if it opens fine.
+
+    os.path.exists() is not enough: it is False for a cert in a directory we
+    cannot search, which is how EACCES ended up in the "no certificates" branch
+    and got a valid cert overwritten (#633).
+    """
+    try:
+        with open(path, 'rb'):
+            return None
+    except OSError as e:
+        return e
+
+
+def _generate_self_signed(cert_file, key_file, domain, app_name):
+    from OpenSSL import crypto
+    key = crypto.PKey()
+    key.generate_key(crypto.TYPE_RSA, 2048)
+    cert = crypto.X509()
+    cert.get_subject().C = "DE"
+    cert.get_subject().ST = "State"
+    cert.get_subject().L = "City"
+    cert.get_subject().O = app_name or "PegaProx"
+    cert.get_subject().OU = app_name or "PegaProx"
+    cert.get_subject().CN = domain or app_name or "PegaProx"
+    cert.set_serial_number(1000)
+    cert.gmtime_adj_notBefore(0)
+    cert.gmtime_adj_notAfter(365 * 24 * 60 * 60)
+    cert.set_issuer(cert.get_subject())
+    cert.set_pubkey(key)
+    cert.sign(key, 'sha256')
+    with open(cert_file, "wb") as f:
+        f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+    with open(key_file, "wb") as f:
+        f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
+    os.chmod(key_file, 0o600)
+
+
+def _resolve_ssl_context(reverse_proxy, domain='', app_name='PegaProx',
+                         cert_file=SSL_CERT_FILE, key_file=SSL_KEY_FILE):
+    """(cert, key) for the TLS listener, or None for plaintext.
+
+    Posture (#633): TLS unless a reverse proxy terminates it for us. If TLS is
+    the posture and we cannot load or generate a usable pair, we do not come up.
+    """
+    if reverse_proxy:
+        return None      # nginx/haproxy/traefik owns TLS, plain HTTP on the bind
+
+    cert_err, key_err = _unreadable(cert_file), _unreadable(key_file)
+    if cert_err is None and key_err is None:
+        print("SSL certificates found - starting with HTTPS")
+        return (cert_file, key_file)
+
+    # Present but not readable is NOT "missing". Never generate over it - that
+    # would report the wrong problem, and destroy a working cert if the write
+    # happened to succeed.
+    for path, err in ((cert_file, cert_err), (key_file, key_err)):
+        if err is not None and err.errno != errno.ENOENT:
+            return _tls_setup_failed("cannot read %s: %s" % (path, err.strerror), path)
+
+    # MK 2026-06-08 (#531): generate into the persisted config/ssl dir, and
+    # create the dir first - on a fresh container the old target did not exist,
+    # generation failed with ENOENT and we fell back to plain HTTP.
+    print("No SSL certificates found. Generating self-signed certificate...")
+    try:
+        os.makedirs(os.path.dirname(os.path.abspath(cert_file)), exist_ok=True)
+        _generate_self_signed(cert_file, key_file, domain, app_name)
+    except ImportError:
+        return _tls_setup_failed("pyOpenSSL is not installed (pip install pyOpenSSL)", cert_file)
+    except Exception as e:
+        return _tls_setup_failed("could not generate one: %s" % e, cert_file)
+    print("Self-signed certificate generated: %s" % cert_file)
+    return (cert_file, key_file)
+
+
 def main(debug_mode=False):
     """Main entry point - starts PegaProx server."""
     from pegaprox.utils.auth import load_users, load_sessions, backfill_initialized_marker, is_initialized
@@ -935,77 +1072,22 @@ def main(debug_mode=False):
             bind_host = '0.0.0.0'
 
     # MK: when behind proxy, SSL is handled by nginx/haproxy - we run plain HTTP
-    ssl_enabled = server_settings.get('ssl_enabled', False) and not reverse_proxy
+    #
+    # SP Jul 2026: the `ssl_enabled` setting is deliberately NOT read here. The old
+    # code only used it as a fast path, and its else-branch generated a cert and
+    # served HTTPS anyway, so with the setting off (the default, api/helpers.py)
+    # every install still ran TLS. Reading it now would drop those installs to
+    # cleartext on upgrade. Posture stays "TLS unless a reverse proxy terminates
+    # it"; making the toggle mean something is a separate change.
     domain = server_settings.get('domain', '')
     app_name = server_settings.get('app_name', 'PegaProx')
     if reverse_proxy:
         print("SSL disabled (handled by reverse proxy)")
 
-    # Check for SSL certificates (skip entirely behind reverse proxy)
-    ssl_context = None
-    if reverse_proxy:
-        pass  # nginx handles SSL
-    elif ssl_enabled and os.path.exists(SSL_CERT_FILE) and os.path.exists(SSL_KEY_FILE):
-        ssl_context = (SSL_CERT_FILE, SSL_KEY_FILE)
-        print("Custom SSL certificates found - starting with HTTPS")
-    else:
-
-        # We validate this path for the Debian package
-        if Path("/usr/lib/pegaprox").exists():
-            DATA_DIR = Path("/var/lib/pegaprox")
-        else:
-            DATA_DIR = Path(__file__).resolve().parent.parent
-
-        SSL_DIR = DATA_DIR / "ssl"
-
-        # MK 2026-06-08 (#531): generate the self-signed cert into the persisted
-        # config/ssl dir (the same path the custom-cert check above uses + the one
-        # that survives a `docker compose pull`) AND create it first. On a fresh
-        # container the old /app/ssl target didn't exist, so generation failed with
-        # ENOENT, PegaProx fell back to plain HTTP, and a browser hitting it over
-        # HTTPS got a TLS-to-HTTP "connection error" — login was impossible.
-        cert_file = SSL_CERT_FILE
-        key_file = SSL_KEY_FILE
-        try:
-            os.makedirs(os.path.dirname(cert_file), exist_ok=True)
-        except Exception:
-            pass
-
-        if os.path.exists(cert_file) and os.path.exists(key_file):
-            ssl_context = (cert_file, key_file)
-            print("SSL certificates found - starting with HTTPS")
-        else:
-            print("No SSL certificates found. Generating self-signed certificate...")
-            try:
-                from OpenSSL import crypto
-                key = crypto.PKey()
-                key.generate_key(crypto.TYPE_RSA, 2048)
-                cert = crypto.X509()
-                cert.get_subject().C = "DE"
-                cert.get_subject().ST = "State"
-                cert.get_subject().L = "City"
-                cert.get_subject().O = app_name or "PegaProx"
-                cert.get_subject().OU = app_name or "PegaProx"
-                cert.get_subject().CN = domain or app_name or "PegaProx"
-                cert.set_serial_number(1000)
-                cert.gmtime_adj_notBefore(0)
-                cert.gmtime_adj_notAfter(365 * 24 * 60 * 60)
-                cert.set_issuer(cert.get_subject())
-                cert.set_pubkey(key)
-                cert.sign(key, 'sha256')
-                with open(cert_file, "wb") as f:
-                    f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
-                with open(key_file, "wb") as f:
-                    f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
-                os.chmod(key_file, 0o600)
-                ssl_context = (cert_file, key_file)
-                print(f"Self-signed certificate generated: {cert_file}")
-            except ImportError:
-                print("WARNING: pyOpenSSL not installed. Run: pip install pyOpenSSL")
-                print("Starting without HTTPS (noVNC may not work)")
-            except Exception as e:
-                print(f"WARNING: Could not generate SSL certificate: {e}")
-                print("Starting without HTTPS (noVNC may not work)")
+    # Check for SSL certificates (skip entirely behind reverse proxy).
+    # SP Jul 2026 (#633): fail closed - see _resolve_ssl_context(). This used to warn
+    # and fall through to plain HTTP on the port that was meant to be TLS.
+    ssl_context = _resolve_ssl_context(reverse_proxy, domain, app_name)
 
     # Start HTTP redirect server if SSL is enabled (not needed behind reverse proxy)
     http_redirect_port = server_settings.get('http_redirect_port', 0)

--- a/pegaprox/constants.py
+++ b/pegaprox/constants.py
@@ -77,16 +77,34 @@ STATIC_DIR = 'static'
 IMAGES_DIR = 'images'
 PLUGINS_DIR = 'plugins'
 
+# SP Jul 2026 (#633): everything below runs at IMPORT time, so any script that
+# merely imports pegaprox.* as another user does it as that user. A root-run
+# helper (a test runner, in the reported case) created config/ssl and copied the
+# certs there as root, the service started as its own user, could not read them,
+# and the old startup path answered that by serving cleartext on the TLS port.
+# So: only touch config/ when we own it, i.e. when files we create there would
+# belong to its owner anyway. Nothing here is load-bearing for a foreign user -
+# main() creates what it needs before generating a cert.
+def _config_owned_by_us():
+    try:
+        return os.stat(CONFIG_DIR).st_uid == os.geteuid()
+    except OSError:
+        return True      # not there yet, we are the one creating it
+
+
+CONFIG_OWNED_BY_US = _config_owned_by_us()
+
 # Ensure directories exist
 Path(LOG_DIR).mkdir(exist_ok=True)
 Path(PLUGINS_DIR).mkdir(exist_ok=True)
 Path(WEB_DIR).mkdir(exist_ok=True)
-Path(SSL_DIR).mkdir(parents=True, exist_ok=True)
-Path(BRANDING_DIR).mkdir(parents=True, exist_ok=True)
-try:
-    os.chmod(SSL_DIR, 0o700)
-except Exception:
-    pass
+if CONFIG_OWNED_BY_US:
+    Path(SSL_DIR).mkdir(parents=True, exist_ok=True)
+    Path(BRANDING_DIR).mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(SSL_DIR, 0o700)
+    except Exception:
+        pass
 
 # One-time migration: legacy 'ssl/cert.pem' / 'images/login_bg.*' → config/
 # Runs every startup but only when the legacy file exists AND the persistent
@@ -94,6 +112,10 @@ except Exception:
 # read-only fallback so a misconfigured downgrade doesn't lose certs.
 def _migrate_to_config():
     import shutil
+    if not CONFIG_OWNED_BY_US:
+        # a foreign user would leave root-owned certs behind and lock the service
+        # out of its own config/ssl (#633)
+        return
     try:
         for src, dst in ((SSL_CERT_FILE_LEGACY, SSL_CERT_FILE),
                          (SSL_KEY_FILE_LEGACY, SSL_KEY_FILE)):

--- a/tests/test_ssl_bootstrap.py
+++ b/tests/test_ssl_bootstrap.py
@@ -1,0 +1,201 @@
+# TLS bootstrap posture - app.py::_resolve_ssl_context().
+#
+# SP Jul 2026 (#633): if TLS was the intended posture and the cert could not be
+# read or generated, PegaProx printed a WARNING and then bound PLAINTEXT HTTP on
+# the port that was meant to be TLS. Every TLS client in front of it spoke TLS
+# into a cleartext socket ("Invalid http version: '\x16\x03\x01...'") while the
+# service reported itself healthy. That is a fail-open downgrade.
+#
+# Posture now: TLS unless behind a reverse proxy. If TLS cannot be established we
+# refuse to start, unless plaintext is asked for explicitly with
+# PEGAPROX_ALLOW_PLAINTEXT=1.
+#
+# The other half of the bug was diagnostics: both branches gated on
+# os.path.exists(), which is False for a cert sitting in a directory the service
+# user cannot search. So EACCES and ENOENT collapsed into one branch and the
+# operator was told "No SSL certificates found" about files that were present and
+# valid. Unreadable and missing must never read the same.
+
+import logging
+import os
+import stat
+
+import pytest
+
+from pegaprox import app as app_module
+
+pytestmark = pytest.mark.skipif(os.geteuid() == 0,
+                                reason='root ignores file permissions, so no case here can fail closed')
+
+
+@pytest.fixture
+def certs(tmp_path):
+    """A usable cert/key pair in its own directory, plus a chmod that gets undone."""
+    d = tmp_path / 'ssl'
+    d.mkdir()
+    cert, key = d / 'cert.pem', d / 'key.pem'
+    cert.write_bytes(b'-- not a real cert, nothing here parses it --\n')
+    key.write_bytes(b'-- not a real key --\n')
+    yield cert, key
+    for p in (cert, key, d):        # so tmp_path teardown can still remove it
+        try:
+            os.chmod(p, 0o700)
+        except OSError:
+            pass
+
+
+def _resolve(cert, key, **kw):
+    kw.setdefault('reverse_proxy', False)
+    return app_module._resolve_ssl_context(cert_file=str(cert), key_file=str(key), **kw)
+
+
+def test_reverse_proxy_means_plaintext_by_design(certs):
+    # nginx/traefik terminates TLS, so plain HTTP on the bind is the intent
+    cert, key = certs
+    assert _resolve(cert, key, reverse_proxy=True) is None
+
+
+def test_readable_pair_is_used(certs):
+    cert, key = certs
+    assert _resolve(cert, key) == (str(cert), str(key))
+
+
+def test_unreadable_cert_refuses_to_start(certs, capsys):
+    cert, key = certs
+    os.chmod(cert, 0o000)
+    with pytest.raises(SystemExit) as e:
+        _resolve(cert, key)
+    msg = str(e.value)
+    assert 'Permission denied' in msg or 'EACCES' in msg
+    assert str(cert) in msg                          # resolved path, not a relative guess
+    # the certs are right there - neither the message nor the startup log may claim
+    # otherwise, and generation must not have been attempted over them at all
+    assert 'No SSL certificates found' not in msg
+    out = capsys.readouterr().out
+    assert 'No SSL certificates found' not in out
+    assert 'Generating self-signed' not in out
+    # and they were never truncated (stat works on a 0000 file, reading does not)
+    assert os.stat(cert).st_size == len(b'-- not a real cert, nothing here parses it --\n')
+
+
+def test_unreadable_key_refuses_to_start(certs):
+    # cert readable, key not - still fail closed, not "missing"
+    cert, key = certs
+    os.chmod(key, 0o000)
+    with pytest.raises(SystemExit) as e:
+        _resolve(cert, key)
+    assert str(key) in str(e.value)
+
+
+def test_unsearchable_directory_refuses_to_start(certs, capsys):
+    # the reported case: config/ssl is 0700 root:root, service user is not root.
+    # os.path.exists() returns False here, which is what made the old code print
+    # "No SSL certificates found" and then generate over a perfectly good cert.
+    cert, key = certs
+    os.chmod(cert.parent, 0o000)
+    with pytest.raises(SystemExit) as e:
+        _resolve(cert, key)
+    assert 'No SSL certificates found' not in str(e.value)
+    assert 'No SSL certificates found' not in capsys.readouterr().out
+
+
+def test_error_names_the_directory_owner_and_mode(certs):
+    cert, key = certs
+    os.chmod(cert, 0o000)
+    msg = str(pytest.raises(SystemExit, _resolve, cert, key).value)
+    assert str(cert.parent) in msg
+    assert 'mode=' in msg and 'owner=' in msg
+    assert 'uid=' in msg                             # who we are, to compare against
+
+
+def test_missing_pair_is_generated(certs):
+    cert, key = certs
+    cert.unlink()
+    key.unlink()
+    assert _resolve(cert, key, domain='pegaprox.test') == (str(cert), str(key))
+    assert cert.read_bytes().startswith(b'-----BEGIN CERTIFICATE-----')
+    assert stat.S_IMODE(os.stat(key).st_mode) == 0o600
+
+
+def test_generation_failure_refuses_to_start(certs):
+    cert, key = certs
+    cert.unlink()
+    key.unlink()
+    os.chmod(cert.parent, 0o500)                     # readable, not writable
+    with pytest.raises(SystemExit) as e:
+        _resolve(cert, key)
+    assert str(cert.parent) in str(e.value)
+
+
+def test_missing_pyopenssl_refuses_to_start(certs, monkeypatch):
+    cert, key = certs
+    cert.unlink()
+    key.unlink()
+    monkeypatch.setitem(__import__('sys').modules, 'OpenSSL', None)
+    with pytest.raises(SystemExit) as e:
+        _resolve(cert, key)
+    assert 'pyOpenSSL' in str(e.value)
+
+
+def test_plaintext_needs_an_explicit_opt_in(certs, monkeypatch, caplog):
+    # the escape hatch for anyone who really does want cleartext on that port
+    cert, key = certs
+    os.chmod(cert, 0o000)
+    monkeypatch.setenv('PEGAPROX_ALLOW_PLAINTEXT', '1')
+    with caplog.at_level(logging.ERROR):
+        assert _resolve(cert, key) is None
+    logged = '\n'.join(r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR)
+    assert 'PLAINTEXT' in logged.upper()             # ERROR level, and it says what it means
+    assert 'PEGAPROX_ALLOW_PLAINTEXT' in logged
+
+
+def test_config_guard_reads_the_owner(monkeypatch):
+    # constants.py does its mkdir/chmod/copy at IMPORT time, so a root-run script
+    # that just imports pegaprox.* used to create config/ssl as root and lock the
+    # service user out of its own certs - the trigger behind #633.
+    from pegaprox import constants
+
+    class _St:
+        def __init__(self, uid):
+            self.st_uid = uid
+
+    monkeypatch.setattr(constants.os, 'stat', lambda p: _St(os.geteuid()))
+    assert constants._config_owned_by_us() is True
+
+    monkeypatch.setattr(constants.os, 'stat', lambda p: _St(os.geteuid() + 1))
+    assert constants._config_owned_by_us() is False
+
+    def _gone(p):
+        raise FileNotFoundError(2, 'No such file or directory')
+
+    monkeypatch.setattr(constants.os, 'stat', _gone)
+    assert constants._config_owned_by_us() is True     # fresh install, we create it
+
+
+def test_migration_only_runs_when_we_own_config(tmp_path, monkeypatch):
+    from pegaprox import constants
+    legacy = tmp_path / 'legacy_cert.pem'
+    legacy.write_bytes(b'the real cert')
+    dst = tmp_path / 'config_cert.pem'
+    monkeypatch.setattr(constants, 'SSL_CERT_FILE_LEGACY', str(legacy))
+    monkeypatch.setattr(constants, 'SSL_CERT_FILE', str(dst))
+    monkeypatch.setattr(constants, 'SSL_KEY_FILE_LEGACY', str(tmp_path / 'absent_key.pem'))
+    monkeypatch.setattr(constants, 'SSL_KEY_FILE', str(tmp_path / 'absent_key_dst.pem'))
+    monkeypatch.setattr(constants, 'BRANDING_DIR', str(tmp_path))
+
+    monkeypatch.setattr(constants, 'CONFIG_OWNED_BY_US', False)
+    constants._migrate_to_config()
+    assert not dst.exists()                          # would have been ours, not the service's
+
+    monkeypatch.setattr(constants, 'CONFIG_OWNED_BY_US', True)
+    constants._migrate_to_config()
+    assert dst.read_bytes() == b'the real cert'      # and it still migrates normally
+
+
+@pytest.mark.parametrize('value', ['0', 'false', 'no', '', ' '])
+def test_falsy_opt_in_still_fails_closed(certs, monkeypatch, value):
+    cert, key = certs
+    os.chmod(cert, 0o000)
+    monkeypatch.setenv('PEGAPROX_ALLOW_PLAINTEXT', value)
+    with pytest.raises(SystemExit):
+        _resolve(cert, key)

--- a/update.sh
+++ b/update.sh
@@ -364,6 +364,13 @@ if [ "$EUID" -eq 0 ] && [ -n "$ORIGINAL_OWNER" ] && [ "$ORIGINAL_OWNER" != "root
     chown -R "$ORIGINAL_OWNER" web/ 2>/dev/null
     [ -d "pegaprox" ] && chown -R "$ORIGINAL_OWNER" pegaprox/ 2>/dev/null
     chown -R "$ORIGINAL_OWNER" backups/ 2>/dev/null
+    # images/ was missing here - left root:root on a non-root install (#633)
+    [ -d "images" ] && chown -R "$ORIGINAL_OWNER" images/ 2>/dev/null
+    # config/ too: we chmod 700 it further down, so a single root-owned file in
+    # there (a root-run import can create config/ssl/cert.pem) locks the service
+    # user out of its own certs. ORIGINAL_OWNER is read from config/ itself, so
+    # this only ever repairs children (#633).
+    [ -d "config" ] && chown -R "$ORIGINAL_OWNER" config/ 2>/dev/null
     echo -e "${GREEN}OK${NC}"
 fi
 


### PR DESCRIPTION
## **User description**
Closes #633.

## What's wrong

If TLS was the intended posture and the cert could not be read or generated, PegaProx printed a `WARNING` and then bound **plaintext HTTP on the port that was meant to be TLS**:

```
WARNING: Could not generate SSL certificate: [Errno 13] Permission denied: 'config/ssl/cert.pem'
Starting without HTTPS (noVNC may not work)
... Invalid http version: '\x16\x03\x01\x05ñ\x01\x00\x05í...'
```

Those `\x16\x03\x01` are TLS ClientHellos landing on a cleartext listener. The service stays `active` and reports itself healthy while the dashboard is unreachable. #531 fixed one trigger of that fallback, not the fallback.

Second half of the bug: `app.py:948` and `:974` both gated on `os.path.exists()`, which is **False** for a cert in a directory the service user cannot search. So `EACCES` and `ENOENT` collapsed into one branch, the operator was told `No SSL certificates found` about files that were present and valid, and generation then tried to write over them.

## What this does

1. **Fail closed.** The 65 inline lines in `main()` moved into `_resolve_ssl_context()`. It returns a pair, returns `None` only for a reverse proxy or an explicit opt-in, and otherwise raises `SystemExit`. Being a function is also what made it testable.
2. **Unreadable is not missing.** Readability is probed by opening the file. Only a real `ENOENT` leads to generation, so a present-but-unreachable cert is never overwritten and never described as absent.
3. **The error says what to fix:**

```
TLS is enabled but there is no usable certificate: cannot read /opt/PegaProx/config/ssl/cert.pem: Permission denied
  /opt/PegaProx/config/ssl/cert.pem cannot stat: Permission denied
  /opt/PegaProx/config/ssl owner=root:root mode=0o700
  this process uid=997(pegaprox) gid=997(pegaprox)
  Refusing to serve plaintext on the TLS port. Fix the certificate, or put PegaProx behind a reverse proxy (the reverse_proxy setting), or set PEGAPROX_ALLOW_PLAINTEXT=1 to serve cleartext there on purpose.
```

4. **Import-time side effects guarded** (`constants.py`). The `mkdir`/`chmod`/`copy2` of `config/ssl` ran at import, so any script importing `pegaprox.*` as another user performed the 0.9.15 `ssl/` → `config/ssl` migration as that user - which is how the reported cluster got root-owned certs. Those steps now only run when `config/` is already owned by the current process. Nothing there is load-bearing for a foreign user, `main()` creates what it needs before generating.
5. **`update.sh` restores ownership of `images/` and `config/` too.** `images/` was simply missing. `config/` matters more: `update.sh` chmods it `700` further down, so one root-owned file inside locks the service user out of its own certs. `ORIGINAL_OWNER` is read from `config/` itself, so this only ever repairs children.

## Behavior change, worth a second read before merging

- An install where TLS is the posture and the cert is broken now **refuses to start** instead of serving cleartext. That is the point, but it turns a silent degradation into a hard failure at boot.
- Escape hatches: the `reverse_proxy` setting, or `PEGAPROX_ALLOW_PLAINTEXT=1` which serves HTTP and logs at ERROR saying every TLS client will fail.
- **`ssl_enabled` is still not consulted, on purpose.** The old code used it only as a fast path, and its else-branch generated a cert and served HTTPS anyway - so with the setting off, which is the default in `api/helpers.py`, installs still ran TLS. Reading it now would drop all of them to cleartext on upgrade. Making that toggle mean something is a separate change and needs its own decision.

## Testing

`tests/test_ssl_bootstrap.py`, 17 cases: reverse proxy, readable pair, unreadable cert, unreadable key, unsearchable directory, owner/mode in the message, generation, generation failure, missing pyOpenSSL, the opt-in, five falsy opt-in values, both directions of the ownership guard. Suite: **294 passed**.

Checked the tests fail on a regression - four mutations, each reverted:

| mutation | caught by |
|---|---|
| fail open again (`return None` instead of `SystemExit`) | 11 tests |
| back to `os.path.exists()` | 9 tests |
| drop the `ENOENT` distinction | 2 tests (the misleading stdout line) |
| remove the config-ownership guard | 1 test |

Not verified on a live service yet - unit-level only. I can run it on my cluster if you want that before merge.


___

## **CodeAnt-AI Description**
Fail closed when TLS cannot start instead of serving plaintext

### What Changed
- PegaProx now refuses to start when TLS is expected but certificates cannot be read or generated, preventing TLS clients from reaching a plaintext port.
- Plain HTTP remains available behind a reverse proxy or only when explicitly enabled with `PEGAPROX_ALLOW_PLAINTEXT=1`.
- Unreadable certificates and keys are reported as permission or access errors instead of being treated as missing or overwritten.
- Startup errors include certificate paths, ownership, permissions, and the running user to identify configuration problems.
- Configuration migration and updates avoid leaving certificate and image files inaccessible to the service user.
- Added coverage for missing, unreadable, unsearchable, and successfully generated certificates, plus explicit plaintext opt-in behavior.

### Impact
`✅ No accidental plaintext service on the TLS port`
`✅ Clearer certificate permission errors`
`✅ Fewer startup failures caused by inaccessible configuration files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
