### PR TITLE
oidc(#486): keep the full preferred_username instead of truncating at…

### DIFF
--- a/pegaprox/api/auth.py
+++ b/pegaprox/api/auth.py
@@ -214,8 +214,8 @@ def oidc_callback():
         # Check if user already exists
         # MK: this has to match the logic in oidc_provision_user or we get mismatches
         # (had a bug where "john.doe" here vs "johndoe" in provision caused 403s)
-        check_username = oidc_derive_username(user_info)
         users = load_users()
+        check_username = oidc_derive_username(user_info, users)
         if check_username not in users:
             return jsonify({'error': 'User account does not exist. Contact an administrator.'}), 403
     

--- a/pegaprox/api/auth.py
+++ b/pegaprox/api/auth.py
@@ -32,6 +32,7 @@ from pegaprox.utils.oidc import (
     get_oidc_settings, get_oidc_endpoints, oidc_build_auth_url,
     oidc_exchange_code, oidc_decode_id_token, oidc_get_user_info,
     oidc_get_user_groups, oidc_map_groups_to_role, oidc_provision_user,
+    oidc_derive_username,
 )
 from pegaprox.utils.rbac import get_user_permissions, DEFAULT_TENANT_ID
 from pegaprox.api.helpers import load_server_settings, save_server_settings, get_login_settings, get_session_timeout, safe_error, effective_reverse_proxy
@@ -213,12 +214,7 @@ def oidc_callback():
         # Check if user already exists
         # MK: this has to match the logic in oidc_provision_user or we get mismatches
         # (had a bug where "john.doe" here vs "johndoe" in provision caused 403s)
-        email = user_info.get('email') or user_info.get('preferred_username', '')
-        raw_username = user_info.get('preferred_username') or email
-        check_username = raw_username.split('@')[0].lower() if '@' in raw_username else raw_username.lower()
-        check_username = ''.join(c for c in check_username if c.isalnum() or c in '._-')
-        if not check_username:
-            check_username = f"oidc_{user_info.get('sub', 'unknown')[:12]}"
+        check_username = oidc_derive_username(user_info)
         users = load_users()
         if check_username not in users:
             return jsonify({'error': 'User account does not exist. Contact an administrator.'}), 403

--- a/pegaprox/utils/oidc.py
+++ b/pegaprox/utils/oidc.py
@@ -621,6 +621,33 @@ def oidc_map_groups_to_role(config: dict, groups: list, id_token_claims: dict = 
     return result
 
 
+def oidc_derive_username(user_info: dict) -> str:
+    """Derive the local username key from OIDC claims.
+
+    LW: keep the full preferred_username including the domain. Truncating at
+    '@' collapsed bob@corp.com and bob@partner.com onto one account, so the
+    second one to log in inherited the first one's role and tenant.
+    """
+    from pegaprox.utils.auth import load_users
+
+    raw_username = (user_info.get('preferred_username')
+                    or user_info.get('email', ''))
+
+    username = ''.join(c for c in raw_username.lower()
+                       if c.isalnum() or c in '._-@')
+    if not username:
+        return f"oidc_{user_info.get('sub', 'unknown')[:12]}"
+
+    # Back-compat: installs before this change stored the part before '@'.
+    # An existing account keeps its old key so it isn't orphaned.
+    if '@' in username:
+        legacy = username.split('@')[0]
+        if legacy and legacy in load_users():
+            return legacy
+
+    return username
+
+
 def oidc_provision_user(user_info: dict, role_mapping: dict, auth_source: str = 'oidc') -> dict:
     from pegaprox.utils.auth import load_users, save_users
     """Create or update local user from OIDC authentication
@@ -630,19 +657,8 @@ def oidc_provision_user(user_info: dict, role_mapping: dict, auth_source: str = 
     """
     # Derive username from OIDC claims
     email = user_info.get('email') or user_info.get('preferred_username', '')
-    raw_username = user_info.get('preferred_username') or email
-    
-    # LW: Sanitize username - use part before @ for email-style usernames
-    if '@' in raw_username:
-        username = raw_username.split('@')[0].lower()
-    else:
-        username = raw_username.lower()
-    
-    # NS: Ensure we have a valid username
-    username = ''.join(c for c in username if c.isalnum() or c in '._-')
-    if not username:
-        username = f"oidc_{user_info.get('sub', 'unknown')[:12]}"
-    
+    username = oidc_derive_username(user_info)
+
     display_name = user_info.get('name') or user_info.get('given_name', '') 
     if not display_name:
         display_name = username

--- a/pegaprox/utils/oidc.py
+++ b/pegaprox/utils/oidc.py
@@ -17,6 +17,11 @@ from urllib.parse import urlencode, urlparse, urlunparse
 # NS May 2026 — SSRF guard for admin-supplied OIDC URLs (discovery / token / userinfo).
 from pegaprox.utils.url_security import sanitize_outbound_url, SsrfError
 
+# auth_source values that mean "this row is owned by an OIDC-family IdP", i.e.
+# the ones whose oidc_sub is meaningful. 'local' and 'ldap' rows are excluded on
+# purpose -- they must never be adopted by an OIDC login.
+OIDC_AUTH_SOURCES = ('oidc', 'entra')
+
 
 # MK May 2026 (CodeAnt #500) — pre-validate the authority URL before composing the
 # discovery URL. The existing sanitize_outbound_url() catches the same family of
@@ -621,29 +626,48 @@ def oidc_map_groups_to_role(config: dict, groups: list, id_token_claims: dict = 
     return result
 
 
-def oidc_derive_username(user_info: dict) -> str:
+def oidc_derive_username(user_info: dict, users: dict = None) -> str:
     """Derive the local username key from OIDC claims.
 
     LW: keep the full preferred_username including the domain. Truncating at
     '@' collapsed bob@corp.com and bob@partner.com onto one account, so the
     second one to log in inherited the first one's role and tenant.
+
+    `users` is the already-loaded users table. Callers in the login path have
+    one in hand; passing it avoids a second full-table read per login.
     """
     from pegaprox.utils.auth import load_users
 
     raw_username = (user_info.get('preferred_username')
                     or user_info.get('email', ''))
 
+    # Char set matches sanitize_username()'s allowlist. '+' belongs here for the
+    # same reason '@' does: dropping it silently merges identities, so
+    # a+b@example.com would derive onto a real ab@example.com account.
     username = ''.join(c for c in raw_username.lower()
-                       if c.isalnum() or c in '._-@')
+                       if c.isalnum() or c in '._-@+')
     if not username:
         return f"oidc_{user_info.get('sub', 'unknown')[:12]}"
 
     # Back-compat: installs before this change stored the part before '@'.
-    # An existing account keeps its old key so it isn't orphaned.
+    # An existing account keeps its old key so it isn't orphaned -- but only if
+    # it is provably the SAME identity. Reusing 'bob' merely because a local
+    # part matches would re-open the very collision this function closed:
+    # bob@partner.com would land on the 'bob' row that bob@corp.com created and
+    # inherit its role and tenant. The stored oidc_sub is the IdP's stable,
+    # non-reassignable identifier for the subject, so require it to match the
+    # incoming one exactly. A sub is only unique within an issuer; installs that
+    # repoint at a different IdP have to rekey manually (no issuer is recorded
+    # on the user row to check against).
     if '@' in username:
+        sub = user_info.get('sub', '')
         legacy = username.split('@')[0]
-        if legacy and legacy in load_users():
-            return legacy
+        if legacy and sub:
+            existing = (users if users is not None else load_users()).get(legacy)
+            if (existing
+                    and existing.get('auth_source', 'local') in OIDC_AUTH_SOURCES
+                    and existing.get('oidc_sub') == sub):
+                return legacy
 
     return username
 
@@ -657,14 +681,13 @@ def oidc_provision_user(user_info: dict, role_mapping: dict, auth_source: str = 
     """
     # Derive username from OIDC claims
     email = user_info.get('email') or user_info.get('preferred_username', '')
-    username = oidc_derive_username(user_info)
+    users = load_users()
+    username = oidc_derive_username(user_info, users)
 
-    display_name = user_info.get('name') or user_info.get('given_name', '') 
+    display_name = user_info.get('name') or user_info.get('given_name', '')
     if not display_name:
         display_name = username
-    
-    users = load_users()
-    
+
     if username in users:
         # NS: SECURITY - Don't allow OIDC to overwrite a local-only user
         # This prevents account takeover if someone creates an IdP account matching a local username

--- a/tests/test_oidc_username.py
+++ b/tests/test_oidc_username.py
@@ -1,0 +1,60 @@
+# Username derivation from OIDC claims — oidc_derive_username().
+#
+# The username is the users-table primary key, so how it is derived from the
+# IdP's claims decides which account an OIDC login lands on. This used to
+# truncate at '@', which collapsed bob@corp.com and bob@partner.com onto a
+# single 'bob' account — the second one to log in inherited the first one's
+# role and tenant. The full name is now kept, with a back-compat lookup so
+# installs that already provisioned the truncated form aren't orphaned.
+#
+# Harness note: the `db` fixture is required for every case, not just the
+# legacy one — oidc_derive_username() calls load_users() whenever the derived
+# name contains '@', and without the fixture that would hit the real CONFIG_DIR.
+
+import pytest
+
+from tests.conftest import _seed_user
+
+from pegaprox.utils.oidc import oidc_derive_username
+
+
+def test_preferred_username_keeps_the_domain(db):
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@example.com', 'sub': 's1'}
+    ) == 'bob@example.com'
+
+
+def test_two_domains_stay_distinct(db):
+    """The actual bug: these must not collapse onto one account."""
+    corp = oidc_derive_username({'preferred_username': 'bob@corp.com'})
+    partner = oidc_derive_username({'preferred_username': 'bob@partner.com'})
+    assert corp != partner
+
+
+def test_plain_preferred_username_is_unchanged(db):
+    assert oidc_derive_username(
+        {'preferred_username': 'John.Doe', 'sub': 's2'}
+    ) == 'john.doe'
+
+
+def test_falls_back_to_email(db):
+    assert oidc_derive_username(
+        {'email': 'carol@example.com', 'sub': 's3'}
+    ) == 'carol@example.com'
+
+
+def test_falls_back_to_sub_when_claims_are_empty(db):
+    assert oidc_derive_username({'sub': 'abcdef0123456789'}) == 'oidc_abcdef012345'
+
+
+def test_existing_truncated_account_keeps_its_key(db):
+    """Pre-change installs stored 'bob'; that login must not fork a new account."""
+    _seed_user(db, 'bob')
+    assert oidc_derive_username({'preferred_username': 'bob@example.com'}) == 'bob'
+
+
+def test_unrelated_existing_account_does_not_capture_the_login(db):
+    _seed_user(db, 'alice')
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@example.com'}
+    ) == 'bob@example.com'

--- a/tests/test_oidc_username.py
+++ b/tests/test_oidc_username.py
@@ -15,7 +15,17 @@ import pytest
 
 from tests.conftest import _seed_user
 
+from pegaprox.utils.auth import load_users
 from pegaprox.utils.oidc import oidc_derive_username
+
+
+def _seed_oidc_user(db, username, sub, auth_source='oidc'):
+    """A pre-change row: truncated key, plus the IdP binding a real login left."""
+    _seed_user(db, username)
+    u = db.get_user(username)
+    u['auth_source'] = auth_source
+    u['oidc_sub'] = sub
+    db.save_user(username, u)
 
 
 def test_preferred_username_keeps_the_domain(db):
@@ -29,6 +39,28 @@ def test_two_domains_stay_distinct(db):
     corp = oidc_derive_username({'preferred_username': 'bob@corp.com'})
     partner = oidc_derive_username({'preferred_username': 'bob@partner.com'})
     assert corp != partner
+
+
+def test_plus_addressing_is_preserved(db):
+    """'+' is in sanitize_username()'s allowlist; stripping it merges identities."""
+    assert oidc_derive_username(
+        {'preferred_username': 'a+b@example.com', 'sub': 's4'}
+    ) == 'a+b@example.com'
+
+
+def test_plus_identity_does_not_collide_with_the_bare_one(db):
+    plus = oidc_derive_username({'preferred_username': 'a+b@example.com'})
+    bare = oidc_derive_username({'preferred_username': 'ab@example.com'})
+    assert plus != bare
+
+
+def test_preloaded_users_are_used_instead_of_a_second_read(db):
+    """Callers in the login path pass the table they already loaded."""
+    _seed_oidc_user(db, 'bob', sub='sub-bob')
+    users = load_users()
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@example.com', 'sub': 'sub-bob'}, users
+    ) == 'bob'
 
 
 def test_plain_preferred_username_is_unchanged(db):
@@ -49,12 +81,57 @@ def test_falls_back_to_sub_when_claims_are_empty(db):
 
 def test_existing_truncated_account_keeps_its_key(db):
     """Pre-change installs stored 'bob'; that login must not fork a new account."""
-    _seed_user(db, 'bob')
-    assert oidc_derive_username({'preferred_username': 'bob@example.com'}) == 'bob'
+    _seed_oidc_user(db, 'bob', sub='sub-bob')
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@example.com', 'sub': 'sub-bob'}
+    ) == 'bob'
+
+
+def test_entra_account_also_keeps_its_key(db):
+    _seed_oidc_user(db, 'bob', sub='sub-bob', auth_source='entra')
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@example.com', 'sub': 'sub-bob'}
+    ) == 'bob'
 
 
 def test_unrelated_existing_account_does_not_capture_the_login(db):
     _seed_user(db, 'alice')
     assert oidc_derive_username(
         {'preferred_username': 'bob@example.com'}
+    ) == 'bob@example.com'
+
+
+# ---------------------------------------------------------------------------
+# The back-compat lookup must not become a second route to the original bug.
+# Adopting a legacy row on a bare local-part match would let any subject whose
+# name happens to be 'bob@<anything>' take over the 'bob' account, which is the
+# collision this whole change exists to close.
+
+def test_different_subject_does_not_inherit_the_legacy_account(db):
+    """bob@corp.com owns legacy 'bob'; bob@partner.com must not land on it."""
+    _seed_oidc_user(db, 'bob', sub='sub-corp-bob')
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@partner.com', 'sub': 'sub-partner-bob'}
+    ) == 'bob@partner.com'
+
+
+def test_login_without_a_sub_claim_does_not_adopt_the_legacy_account(db):
+    _seed_oidc_user(db, 'bob', sub='sub-bob')
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@example.com'}
+    ) == 'bob@example.com'
+
+
+def test_local_account_is_not_adopted(db):
+    """A local 'bob' stays local; oidc_provision_user rejects the overwrite."""
+    _seed_user(db, 'bob')  # no auth_source -> 'local'
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@example.com', 'sub': 'sub-bob'}
+    ) == 'bob@example.com'
+
+
+def test_ldap_account_is_not_adopted(db):
+    _seed_oidc_user(db, 'bob', sub='sub-bob', auth_source='ldap')
+    assert oidc_derive_username(
+        {'preferred_username': 'bob@example.com', 'sub': 'sub-bob'}
     ) == 'bob@example.com'


### PR DESCRIPTION
## **User description**
… '@'

Username derivation split preferred_username at '@', so bob@corp.com and bob@partner.com both provisioned onto a single 'bob' account and whoever logged in second inherited the first one's role and tenant.

Keep the whole claim. '@' also has to join the allowed char set, or dropping the split just yields 'bobexample.com'. Nothing downstream constrains it: sanitize_username() already permits '@', LDAP provisioning already produces such names, username is an unconstrained TEXT PRIMARY KEY, and no username reaches a filesystem path, shell command or interpolated SQL.

Existing accounts keep their current key via a back-compat lookup, so no install loses permissions and nobody is locked out under auto_create_users: false. Installs that already hold a truncated 'bob' therefore keep the collision -- closing that needs a rekey migration, left out deliberately.

The derivation was duplicated in the auto_create_users pre-check, with a comment recording that a previous divergence caused 403s. Both call sites now share one helper.

Adds the first test coverage for OIDC username derivation.


___

## **CodeAnt-AI Description**
Keep OIDC usernames distinct across email domains

### What Changed
- OIDC logins now retain the full username, including its domain, so accounts such as `bob@corp.com` and `bob@partner.com` remain separate
- Existing accounts created with truncated usernames continue to use their current account key
- User lookup and automatic provisioning now apply the same username rules
- Added coverage for domain-specific usernames, fallback claims, empty claims, and existing accounts

### Impact
`✅ Prevents cross-domain account collisions`
`✅ Preserves access to existing OIDC accounts`
`✅ Prevents false “account does not exist” login errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC account naming to preserve domains and plus-addressing, preventing identity collisions.
  * Ensured existing legacy accounts are adopted only when their identity matches.
  * Prevented OIDC logins from incorrectly taking over local, LDAP, or unrelated accounts.
  * Added safer fallback handling when preferred identity claims are unavailable.

* **Tests**
  * Added comprehensive coverage for username normalization, identity matching, collision prevention, and legacy account compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->