### PR TITLE
fix PEGAPROX_NO_GEVENT

### DIFF
--- a/pegaprox/app.py
+++ b/pegaprox/app.py
@@ -1194,6 +1194,12 @@ def main(debug_mode=False):
 
     # Start with Gevent if available
     use_gevent = os.environ.get('PEGAPROX_SERVER', 'auto').lower()
+    # Keep behaviour aligned with pegaprox_multi_cluster.py: PEGAPROX_NO_GEVENT
+    # should disable gevent entirely (monkey-patch + WSGI server selection).
+    no_gevent = os.environ.get('PEGAPROX_NO_GEVENT', '').lower() in ('1', 'true', 'yes')
+    if no_gevent and use_gevent in ('auto', 'gevent'):
+        print("PEGAPROX_NO_GEVENT is set - using Flask server path (gevent disabled)")
+        use_gevent = 'flask'
 
     if use_gevent == 'gevent' or (use_gevent == 'auto' and GEVENT_AVAILABLE):
         if GEVENT_AVAILABLE:


### PR DESCRIPTION
## **User description**
fixes an issue where setting `PEGAPROX_NO_GEVENT=true` wasnt being applied correctly
this fix is needed because when i used python 3.14 on ubuntu 26.04, the VNC port would not run or start.
once i added `PEGAPROX_NO_GEVENT=true` the vnc port would then start BUT the web ui was inaccessible
so this fix patches the web ui to be accessible again!


___

## **CodeAnt-AI Description**
Restore web UI availability when running without gevent

### What Changed
- `PEGAPROX_NO_GEVENT=true` now disables gevent for both server setup and server selection
- The application uses the Flask server path when gevent is disabled, allowing the web UI to start and remain accessible

### Impact
`✅ Accessible web UI with gevent disabled`
`✅ VNC startup on environments requiring no gevent`
`✅ Consistent PEGAPROX_NO_GEVENT behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable gevent-based server mode using the `PEGAPROX_NO_GEVENT` setting.
  * Displays a diagnostic message when the setting forces the standard Flask server path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->