### PR TITLE
fix(i18n): provide translator to language switcher

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4352,7 +4352,7 @@ const changeLanguage=useCallback(lang=>{if(!_setAndPersist(lang))return;fetch(`$
 },[_setAndPersist]);// applyLanguage just sets state+localStorage without API call.
 // Used on login/session restore AND on the unauth login page.
 const applyLanguage=useCallback(lang=>{_setAndPersist(lang);},[_setAndPersist]);return/*#__PURE__*/React.createElement(LanguageContext.Provider,{value:{language,t,changeLanguage,applyLanguage,supportedLangs:SUPPORTED_LANGS}},children);}function useTranslation(){return useContext(LanguageContext);}// Language Switcher Component
-function LanguageSwitcher(){const{language,changeLanguage,applyLanguage}=useTranslation();const{isCorporate}=useLayout();// NS May 2026 (#389): On the login page (unauthenticated) we must NOT
+function LanguageSwitcher(){const{language,t,changeLanguage,applyLanguage}=useTranslation();const{isCorporate}=useLayout();// NS May 2026 (#389): On the login page (unauthenticated) we must NOT
 // hit /api/user/preferences — it would always 401 and spam the console.
 // useAuth() reads cleanly here because LanguageSwitcher is rendered
 // inside both providers in the tree.

--- a/web/src/contexts.js
+++ b/web/src/contexts.js
@@ -96,7 +96,7 @@
 
         // Language Switcher Component
         function LanguageSwitcher() {
-            const { language, changeLanguage, applyLanguage } = useTranslation();
+            const { language, t, changeLanguage, applyLanguage } = useTranslation();
             const { isCorporate } = useLayout();
             // NS May 2026 (#389): On the login page (unauthenticated) we must NOT
             // hit /api/user/preferences — it would always 401 and spam the console.


### PR DESCRIPTION
## Summary

- expose the translation function to `LanguageSwitcher`
- rebuild the compiled `web/index.html`

## Root cause

PR #670 changed the Simplified Chinese language title to `t('languageSimplifiedChinese')`, but `LanguageSwitcher` did not destructure `t` from `useTranslation()`. This caused `ReferenceError: t is not defined` during the initial React render and left the page blank.

## Impact

Restores the login and first-time setup UI for deployments based on `Testing`, including the language switcher.

## Validation

- completed the production Babel build
- verified the first-time setup page renders in a fresh browser session
- verified EN ↔ ZH switching
- verified no JavaScript console errors in a fresh session
- verified `/api/health` returns `{"status":"ok","version":"1.0"}` on the affected deployment
- ran `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Language selection labels are now localized according to the currently selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->