### PR TITLE
fix(oidc): apply custom roles from group mappings instead of dropping them 

### DIFF
--- a/pegaprox/utils/oidc.py
+++ b/pegaprox/utils/oidc.py
@@ -598,20 +598,40 @@ def oidc_map_groups_to_role(config: dict, groups: list, id_token_claims: dict = 
     user_group = config.get('user_group_id', '').strip().lower()
     viewer_group = config.get('viewer_group_id', '').strip().lower()
     
+    # KG Aug 2026 — track whether result['role'] is still only oidc_default_role. A group
+    # that actually matched must always be able to replace the default, whatever its rank,
+    # otherwise a custom default_role silently swallows every mapping below.
+    role_from_default = True
+
     if admin_group and (admin_group in group_ids or admin_group in group_names):
         result['role'] = ROLE_ADMIN
+        role_from_default = False
     elif user_group and (user_group in group_ids or user_group in group_names):
         result['role'] = ROLE_USER
+        role_from_default = False
     elif viewer_group and (viewer_group in group_ids or viewer_group in group_names):
         result['role'] = ROLE_VIEWER
-    
+        role_from_default = False
+
     # LW: Custom group mappings — pick highest role when user matches multiple groups
-    _role_prio = {ROLE_VIEWER: 0, ROLE_USER: 1, ROLE_ADMIN: 2}
+    # KG Aug 2026 — custom roles used to be dropped here without a trace: they are absent
+    # from _role_prio, so .get(role, 0) ranked them equal to viewer and the strict `>` never
+    # fired — while the log line below still reported the mapping as matched. Rank them
+    # between user and admin: an explicit mapping onto a custom (e.g. tenant-scoped) role
+    # should beat the coarse viewer/user defaults, but must never demote an admin-group hit.
+    _role_prio = {ROLE_VIEWER: 0, ROLE_USER: 1, ROLE_ADMIN: 3}
+    _CUSTOM_ROLE_PRIO = 2
+
+    def _role_rank(role):
+        return _role_prio.get(role, _CUSTOM_ROLE_PRIO)
+
     for mapping in config.get('group_mappings', []):
         map_group = (mapping.get('group_id') or mapping.get('group_dn') or '').strip().lower()
         if map_group and (map_group in group_ids or map_group in group_names):
-            if mapping.get('role') and _role_prio.get(mapping['role'], 0) > _role_prio.get(result['role'], 0):
+            if mapping.get('role') and (role_from_default
+                                        or _role_rank(mapping['role']) > _role_rank(result['role'])):
                 result['role'] = mapping['role']
+                role_from_default = False
             if mapping.get('tenant'):
                 result['tenant'] = mapping['tenant']
             if mapping.get('permissions'):

--- a/pegaprox/utils/oidc.py
+++ b/pegaprox/utils/oidc.py
@@ -628,8 +628,13 @@ def oidc_map_groups_to_role(config: dict, groups: list, id_token_claims: dict = 
     for mapping in config.get('group_mappings', []):
         map_group = (mapping.get('group_id') or mapping.get('group_dn') or '').strip().lower()
         if map_group and (map_group in group_ids or map_group in group_names):
-            if mapping.get('role') and (role_from_default
-                                        or _role_rank(mapping['role']) > _role_rank(result['role'])):
+            # The configured default stands for "no group matched" (that is how the setting
+            # is labelled in the UI), so a group that DID match may replace it — except when
+            # the default is admin: silently demoting a configured admin on a lower-privilege
+            # match would lock installs out of admin-only workflows.
+            if mapping.get('role') and (
+                    (role_from_default and result['role'] != ROLE_ADMIN)
+                    or _role_rank(mapping['role']) > _role_rank(result['role'])):
                 result['role'] = mapping['role']
                 role_from_default = False
             if mapping.get('tenant'):

--- a/pegaprox/utils/oidc.py
+++ b/pegaprox/utils/oidc.py
@@ -625,9 +625,19 @@ def oidc_map_groups_to_role(config: dict, groups: list, id_token_claims: dict = 
     def _role_rank(role):
         return _role_prio.get(role, _CUSTOM_ROLE_PRIO)
 
+    # KG Aug 2026 — custom roles all share one rank, so when several of them match the
+    # first one in the list wins and the rest tie out. That is deterministic and mirrors
+    # how the mapping list reads top-down, but it IS order-dependent, so say so out loud
+    # instead of quietly picking one: defining a real precedence between custom roles
+    # would mean comparing their permission sets, which is a product decision, not
+    # something to smuggle into a bug fix.
+    matched_custom_roles = []
+
     for mapping in config.get('group_mappings', []):
         map_group = (mapping.get('group_id') or mapping.get('group_dn') or '').strip().lower()
         if map_group and (map_group in group_ids or map_group in group_names):
+            if mapping.get('role') and mapping['role'] not in _role_prio:
+                matched_custom_roles.append(mapping['role'])
             # The configured default stands for "no group matched" (that is how the setting
             # is labelled in the UI), so a group that DID match may replace it — except when
             # the default is admin: silently demoting a configured admin on a lower-privilege
@@ -647,7 +657,15 @@ def oidc_map_groups_to_role(config: dict, groups: list, id_token_claims: dict = 
                     'extra': mapping.get('permissions', [])  # MK: Must be 'extra' to match get_user_permissions()
                 }
             logging.info(f"[OIDC] Custom group mapping matched: {map_group} → role={mapping.get('role')}")
-    
+
+    if len(matched_custom_roles) > 1:
+        logging.warning(
+            f"[OIDC] user matched {len(matched_custom_roles)} custom-role group mappings "
+            f"({', '.join(matched_custom_roles)}); applied '{result['role']}' — custom roles "
+            "share one precedence level, so the first match in the mapping list wins. "
+            "Reorder the mappings if a different role should take precedence."
+        )
+
     return result
 
 

--- a/tests/test_oidc_group_mapping.py
+++ b/tests/test_oidc_group_mapping.py
@@ -1,0 +1,104 @@
+# Group → role mapping for OIDC logins — oidc_map_groups_to_role().
+#
+# Custom roles are a first-class choice in the OIDC config: the "Default role" dropdown
+# lists every non-builtin role, and the settings validator explicitly accepts them in
+# oidc_group_mappings ("NS: Accept custom roles too"). The mapping loop, however, compared
+# roles through a hard-coded {viewer: 0, user: 1, admin: 2} table read with
+# .get(role, 0) — so every custom role tied with viewer and the strict `>` never fired.
+#
+# The mapping was therefore skipped while the log line still reported "Custom group mapping
+# matched: <group> → role=<role>", which made the failure invisible from the outside: users
+# silently landed on oidc_default_role and the logs claimed the mapping had been applied.
+#
+# These cases pin the resulting order — default < viewer < user < custom < admin — plus the
+# rule that a group which actually matched always outranks the bare default. Admin stays on
+# top so existing installs that map an admin group cannot be demoted by a custom mapping.
+#
+# Harness note: oidc_map_groups_to_role() is pure (no DB, no network), so no fixtures.
+
+from pegaprox.models.permissions import ROLE_ADMIN, ROLE_USER, ROLE_VIEWER
+from pegaprox.utils.oidc import oidc_map_groups_to_role
+
+CUSTOM_ROLE = 'tenant-operator-lab'
+
+ADMINS = 'a1111111-1111-1111-1111-111111111111'
+LAB = 'b2222222-2222-2222-2222-222222222222'
+STAFF = 'c3333333-3333-3333-3333-333333333333'
+
+
+def _cfg(**over):
+    cfg = {
+        'default_role': ROLE_VIEWER,
+        'admin_group_id': '',
+        'user_group_id': '',
+        'viewer_group_id': '',
+        'group_mappings': [],
+    }
+    cfg.update(over)
+    return cfg
+
+
+def _groups(*ids):
+    """Entra-shaped membership list: Graph returns {'id': <guid>, 'name': <displayName>}."""
+    return [{'id': g, 'name': f'grp-{g[:4]}'} for g in ids]
+
+
+def test_custom_role_from_group_mapping_is_applied():
+    cfg = _cfg(group_mappings=[{'group_id': LAB, 'role': CUSTOM_ROLE}])
+    assert oidc_map_groups_to_role(cfg, _groups(LAB))['role'] == CUSTOM_ROLE
+
+
+def test_admin_group_is_never_demoted_by_a_custom_mapping():
+    cfg = _cfg(admin_group_id=ADMINS,
+               group_mappings=[{'group_id': LAB, 'role': CUSTOM_ROLE}])
+    assert oidc_map_groups_to_role(cfg, _groups(ADMINS, LAB))['role'] == ROLE_ADMIN
+
+
+def test_admin_mapping_still_wins_over_a_custom_mapping():
+    cfg = _cfg(group_mappings=[
+        {'group_id': LAB, 'role': CUSTOM_ROLE},
+        {'group_id': ADMINS, 'role': ROLE_ADMIN},
+    ])
+    assert oidc_map_groups_to_role(cfg, _groups(LAB, ADMINS))['role'] == ROLE_ADMIN
+
+
+def test_custom_default_role_does_not_swallow_a_matching_mapping():
+    cfg = _cfg(default_role=CUSTOM_ROLE,
+               group_mappings=[{'group_id': STAFF, 'role': ROLE_VIEWER}])
+    assert oidc_map_groups_to_role(cfg, _groups(STAFF))['role'] == ROLE_VIEWER
+
+
+def test_custom_role_outranks_a_plain_user_mapping():
+    cfg = _cfg(group_mappings=[
+        {'group_id': STAFF, 'role': ROLE_USER},
+        {'group_id': LAB, 'role': CUSTOM_ROLE},
+    ])
+    assert oidc_map_groups_to_role(cfg, _groups(STAFF, LAB))['role'] == CUSTOM_ROLE
+
+
+def test_builtin_ladder_is_unchanged():
+    cfg = _cfg(group_mappings=[
+        {'group_id': STAFF, 'role': ROLE_VIEWER},
+        {'group_id': LAB, 'role': ROLE_USER},
+    ])
+    assert oidc_map_groups_to_role(cfg, _groups(STAFF, LAB))['role'] == ROLE_USER
+
+
+def test_no_matching_group_keeps_the_default_role():
+    cfg = _cfg(default_role=CUSTOM_ROLE,
+               group_mappings=[{'group_id': LAB, 'role': ROLE_ADMIN}])
+    assert oidc_map_groups_to_role(cfg, _groups(STAFF))['role'] == CUSTOM_ROLE
+
+
+def test_tenant_and_permissions_from_a_custom_mapping_still_apply():
+    """The role fix must not disturb the other fields the same mapping carries."""
+    cfg = _cfg(group_mappings=[{
+        'group_id': LAB,
+        'role': CUSTOM_ROLE,
+        'tenant': 'lab-waw',
+        'permissions': ['vm.create'],
+    }])
+    out = oidc_map_groups_to_role(cfg, _groups(LAB))
+    assert out['role'] == CUSTOM_ROLE
+    assert out['tenant'] == 'lab-waw'
+    assert 'vm.create' in out['permissions']

--- a/tests/test_oidc_group_mapping.py
+++ b/tests/test_oidc_group_mapping.py
@@ -68,6 +68,18 @@ def test_custom_default_role_does_not_swallow_a_matching_mapping():
     assert oidc_map_groups_to_role(cfg, _groups(STAFF))['role'] == ROLE_VIEWER
 
 
+def test_admin_default_role_is_not_downgraded_by_a_matching_mapping():
+    """An install with default_role='admin' must not lose admin on a lower-privilege match.
+
+    The default otherwise loses to any group that matched, but demoting a configured
+    admin would lock the install out of admin-only workflows, so admin is exempt.
+    """
+    for mapped in (ROLE_VIEWER, ROLE_USER, CUSTOM_ROLE):
+        cfg = _cfg(default_role=ROLE_ADMIN,
+                   group_mappings=[{'group_id': LAB, 'role': mapped}])
+        assert oidc_map_groups_to_role(cfg, _groups(LAB))['role'] == ROLE_ADMIN
+
+
 def test_custom_role_outranks_a_plain_user_mapping():
     cfg = _cfg(group_mappings=[
         {'group_id': STAFF, 'role': ROLE_USER},

--- a/tests/test_oidc_group_mapping.py
+++ b/tests/test_oidc_group_mapping.py
@@ -96,6 +96,29 @@ def test_builtin_ladder_is_unchanged():
     assert oidc_map_groups_to_role(cfg, _groups(STAFF, LAB))['role'] == ROLE_USER
 
 
+def test_first_matching_custom_role_wins_and_the_ambiguity_is_logged(caplog):
+    """Custom roles share one precedence level, so the mapping list order decides.
+
+    That is deterministic, but silently picking one of several matches is the kind of
+    thing an admin should hear about, so it is logged as a warning.
+    """
+    cfg = _cfg(group_mappings=[
+        {'group_id': LAB, 'role': CUSTOM_ROLE},
+        {'group_id': STAFF, 'role': 'tenant-viewer-lab'},
+    ])
+    with caplog.at_level('WARNING'):
+        out = oidc_map_groups_to_role(cfg, _groups(LAB, STAFF))
+    assert out['role'] == CUSTOM_ROLE
+    assert 'custom-role group mappings' in caplog.text
+
+
+def test_a_single_custom_role_match_is_not_flagged_as_ambiguous(caplog):
+    cfg = _cfg(group_mappings=[{'group_id': LAB, 'role': CUSTOM_ROLE}])
+    with caplog.at_level('WARNING'):
+        oidc_map_groups_to_role(cfg, _groups(LAB))
+    assert 'custom-role group mappings' not in caplog.text
+
+
 def test_no_matching_group_keeps_the_default_role():
     cfg = _cfg(default_role=CUSTOM_ROLE,
                group_mappings=[{'group_id': LAB, 'role': ROLE_ADMIN}])


### PR DESCRIPTION
## **User description**
A group mapping onto a custom (e.g. tenant-scoped) role never took effect. The mapping loop ranked roles through a hard-coded {viewer: 0, user: 1, admin: 2} table read with .get(role, 0), so any custom role tied with viewer and the strict `>` comparison never fired — while the log line still reported "Custom group mapping matched", leaving no trace of why the user ended up on oidc_default_role. Custom roles are offered in the config UI (the Default role dropdown lists every non-builtin role) and accepted by the settings validator, so the intent was clearly that they work.

Rank custom roles between user and admin: an explicit mapping onto a custom role now beats the coarse viewer/user defaults, but can never demote someone matched by the admin group. A role that came from oidc_default_role is also tracked separately, so a custom default no longer swallows every mapping.

Adds tests/test_oidc_group_mapping.py — the four custom-role cases fail before this change, the four no-regression cases (admin precedence, builtin ladder, unmatched default) pass both before and after.

Happy to switch to "first match wins" instead if you prefer that ordering — where custom roles sit in the ladder is the one judgement call here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OIDC group-to-role mapping so explicitly matched custom roles override custom default roles.
  * Preserved administrator precedence and the existing built-in role hierarchy.
  * Ensured unmatched groups retain the configured default role.
  * Preserved tenant and permission settings for custom role mappings.
  * Added a warning when multiple custom role mappings match; the first mapping is applied.

* **Tests**
  * Added coverage for custom role precedence, administrator protection, fallback behavior, ambiguity handling, and retained tenant permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Apply custom OIDC group roles without demoting administrators

### What Changed
- Users matched to custom roles now receive those roles during OIDC login.
- Custom roles override viewer or user matches, while administrator matches remain highest priority.
- A matching group can replace a configured custom default role, but cannot downgrade a configured administrator default.
- Group-mapping tests cover custom roles, role precedence, defaults, tenants, and permissions.

### Impact
`✅ Correct custom roles after OIDC login`
`✅ Fewer incorrect default-role assignments`
`✅ Protected administrator access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
