### PR TITLE
feature(update-manager): Add "needrestart" evaluation for nodes during patching

### DIFF
--- a/pegaprox/api/settings.py
+++ b/pegaprox/api/settings.py
@@ -4305,6 +4305,7 @@ def start_rolling_update(cluster_id):
                     # Step 4: If reboot was included, wait for node to come back
                     if include_reboot:
                         mgr._rolling_update['current_step'] = 'rebooting'
+                        mgr._rolling_update['logs'].append(f"[{time.strftime('%H:%M:%S')}] Evaluating if node {node_name} requires a reboot. Analyzing...")
                         mgr._rolling_update['logs'].append(f"[{time.strftime('%H:%M:%S')}] Node {node_name} rebooting (timeout: {reboot_timeout}s)...")
                         if 'rebooting_nodes' not in mgr._rolling_update:
                             mgr._rolling_update['rebooting_nodes'] = []

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -8935,35 +8935,63 @@ echo "AGENT_INSTALLED_OK"
                         stdin, stdout, stderr = ssh.exec_command('id -u')
                         uid = stdout.read().decode().strip()
                         is_root = (uid == '0')
-                        
-                        self.logger.info(f"Sending reboot command to {node_name} (root={is_root})")
-                        task.add_output(f"Running as {'root' if is_root else 'non-root user'}")
-                        
-                        # Get transport and open channel with PTY for sudo support
-                        transport = ssh.get_transport()
-                        channel = transport.open_session()
-                        channel.get_pty()
-                        channel.settimeout(10)
-                        
-                        # Execute reboot command
-                        if is_root:
-                            channel.exec_command('shutdown -r now')
+
+                        # Check if related node requires a reboot
+                        needrestart_utility = False
+                        needrestart_validated = False
+                        self.logger.info(f"Validate if package needrestart is installed on node: {node_name}")
+                        exit_code, output, stderr = self._ssh_execute(ssh, f'{sudo_prefix}dpkg -s needrestart', task)
+
+                        if exit_code == 0:
+                            needrestart_utility = True
+                            self.logger.info(f"Package needrestart is installed on node: {node_name}")
                         else:
-                            channel.exec_command('sudo shutdown -r now')
-                        
-                        # Wait briefly for command to be sent
-                        time.sleep(3)
-                        
-                        # Try to read any output (will fail when connection drops, that's ok)
-                        try:
-                            output = channel.recv(1024).decode()
-                            if output:
-                                task.add_output(f"Reboot output: {output.strip()}")
-                        except:
-                            pass
-                        
-                        channel.close()
-                        task.add_output("Reboot command sent / Reboot-Befehl gesendet")
+                            self.logger.info(f"Package needrestart is not installed on node: {node_name} - forcing to reboot!")
+                            needrestart_validated = True
+
+                        if needrestart_utility:
+                            self.logger.info(f"Validate if node {node_name} requires a restart (needrestart utility mode)")
+                            exit_code, output, stderr = self._ssh_execute(ssh, f'{sudo_prefix}needrestart -p', task)
+                            
+                            if exit_code != 0:
+                                self.logger.info(f"Node {node_name} requires a restart (needrestart utility mode)")
+                                needrestart_validated = True
+                            else:
+                                self.logger.info(f"Node {node_name} does NOT require a restart (needrestart utility mode)")
+
+                        # Run reboot only if this got validated for the related node
+                        if needrestart_validated:
+                            self.logger.info(f"Sending reboot command to {node_name} (root={is_root})")
+                            task.add_output(f"Running as {'root' if is_root else 'non-root user'}")
+                            
+                            # Get transport and open channel with PTY for sudo support
+                            transport = ssh.get_transport()
+                            channel = transport.open_session()
+                            channel.get_pty()
+                            channel.settimeout(10)
+                            
+                            # Execute reboot command
+                            if is_root:
+                                channel.exec_command('shutdown -r now')
+                            else:
+                                channel.exec_command('sudo shutdown -r now')
+                            
+                            # Wait briefly for command to be sent
+                            time.sleep(3)
+                            
+                            # Try to read any output (will fail when connection drops, that's ok)
+                            try:
+                                output = channel.recv(1024).decode()
+                                if output:
+                                    task.add_output(f"Reboot output: {output.strip()}")
+                            except:
+                                pass
+                            
+                            channel.close()
+                            task.add_output("Reboot command sent / Reboot-Befehl gesendet")
+                        else:
+                            self.logger.info(f"Skipping reboot for node: {node_name}")
+                            task.add_output(f"Skipping reboot for node: {node_name}")
                         
                     except Exception as e:
                         self.logger.info(f"Reboot command sent (connection closed as expected): {e}")
@@ -8974,25 +9002,7 @@ echo "AGENT_INSTALLED_OK"
                         except:
                             pass
                         ssh = None
-                else:
-                    task.add_output("[WARN] Could not reconnect for reboot / Konnte nicht für Reboot verbinden")
-                    task.add_output("Trying alternative reboot method / Versuche alternative Methode...")
-                    
-                    # Try via Proxmox API as fallback
-                    try:
-                        # MK May 2026 — was `self.session.post(..., verify=False)` which
-                        # hardcoded the SSL bypass even when the operator configured
-                        # `_ssl_verify=True` on this cluster. Use _create_session()
-                        # so the per-cluster TLS preference is honoured (proper CA
-                        # verification when the user pinned a custom CA bundle).
-                        url = f"https://{self.host}:{self.api_port}/api2/json/nodes/{node_name}/status"
-                        response = self._create_session().post(url, data={'command': 'reboot'})
-                        if response.status_code == 200:
-                            task.add_output("Reboot initiated via Proxmox API")
-                        else:
-                            task.add_output(f"API reboot failed: {response.status_code}")
-                    except Exception as api_e:
-                        task.add_output(f"API reboot also failed: {api_e}")
+
                 
                 task.add_output("Waiting for node to reboot / Warte auf Neustart...")
                 


### PR DESCRIPTION
## **User description**
feature(update-manager): Add "needrestart" evaluation for nodes during patching

  * Check if node has "needrestart" installed
    * Validate by needrestart for a required reboot
  * Fallback to /var/run/reboot-required if needrestart is not present

Fixes: #694

## Details
This PR (re)adds an extended method to validate if a node really requires a reboot. Instead of always rebooting (or skipping), based on the given input options, we should validate if a reboot is really required after the package installation.

Therefore, if `needrestart` is installed on the node, it will gather the information from the utility. If `needrestart` is not present, it falls back  to `/var/run/reboot-required` file validation. If one of them is true, a reboot is requested for the target node.

What should be done within the next PRs:
* [ ] Add option to install the `needrestart` Debian package directly from the PegaProx UI to all nodes in a scoped cluster
* [ ] Bi-directional communication from the `run_rolling_update` function back to the manager to gather live evaluations if a reboot is required. We currently only cover this by the logger, but not to the frontend manager.

## Tests

## Manager Example
<img width="1804" height="475" alt="pegaprox_update_mgr" src="https://github.com/user-attachments/assets/f3dd0900-df6d-49b7-b6b5-0facc46a6d2b" />

## No reboot required
Testing when packages are available but no reboot is required.
Validation: Skipping the reboot
```
Aug 17 07:25:42 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:42,937] [PegaProx_dev] INFO: [NodeIP] de-fra03-dev-gyptazy02 -> 10.10.10.94 (cluster/status, reachable on :22)
Aug 17 07:25:42 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:42,937] [PegaProx_dev] INFO: Connecting to 10.10.10.94:22 as root...
Aug 17 07:25:43 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:43,056] [PegaProx_dev] INFO: SSH connected to 10.10.10.94
Aug 17 07:25:43 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:43,074] [PegaProx_dev] INFO: Executing: DEBIAN_FRONTEND=noninteractive apt-get update
Aug 17 07:25:44 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:44,108] [PegaProx_dev] INFO: Executing: DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
Aug 17 07:25:48 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:48,996] [PegaProx_dev] INFO: Executing: apt-get autoremove -y
Aug 17 07:25:49 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:49,601] [PegaProx_dev] INFO: Executing: apt-get autoclean
Aug 17 07:25:49 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:49,862] [PegaProx_dev] INFO: Connecting to 10.10.10.94:22 as root...
Aug 17 07:25:49 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:49,981] [PegaProx_dev] INFO: SSH connected to 10.10.10.94
Aug 17 07:25:49 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:49,999] [PegaProx_dev] INFO: Validate if package needrestart is installed on node: de-fra03-dev-gyptazy02
Aug 17 07:25:49 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:49,999] [PegaProx_dev] INFO: Executing: dpkg -s needrestart
Aug 17 07:25:50 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:50,069] [PegaProx_dev] INFO: Package needrestart is installed on node: de-fra03-dev-gyptazy02
Aug 17 07:25:50 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:50,069] [PegaProx_dev] INFO: Validate if node de-fra03-dev-gyptazy02 requires a restart (needrestart utility mode)
Aug 17 07:25:50 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:50,069] [PegaProx_dev] INFO: Executing: needrestart -p
Aug 17 07:25:50 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:50,260] [PegaProx_dev] INFO: Node de-fra03-dev-gyptazy02 does NOT require a restart (needrestart utility mode)
Aug 17 07:25:50 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:25:50,260] [PegaProx_dev] INFO: Skipping reboot for node: de-fra03-dev-gyptazy02
```

## Reboot required
Testing when packages are available and a reboot is required.
Validation: Reboot is being processed
```
Aug 17 07:27:28 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:28,972] [PegaProx_dev] INFO: [NodeIP] de-fra03-dev-gyptazy02 -> 10.10.10.94 (cluster/status, reachable on :22)
Aug 17 07:27:28 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:28,972] [PegaProx_dev] INFO: Connecting to 10.10.10.94:22 as root...
Aug 17 07:27:29 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:29,090] [PegaProx_dev] INFO: SSH connected to 10.10.10.94
Aug 17 07:27:29 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:29,108] [PegaProx_dev] INFO: Executing: DEBIAN_FRONTEND=noninteractive apt-get update
Aug 17 07:27:30 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:30,116] [PegaProx_dev] INFO: Executing: DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
Aug 17 07:27:35 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:35,057] [PegaProx_dev] INFO: Executing: apt-get autoremove -y
Aug 17 07:27:35 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:35,714] [PegaProx_dev] INFO: Executing: apt-get autoclean
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,003] [PegaProx_dev] INFO: Connecting to 10.10.10.94:22 as root...
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,125] [PegaProx_dev] INFO: SSH connected to 10.10.10.94
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,143] [PegaProx_dev] INFO: Validate if package needrestart is installed on node: de-fra03-dev-gyptazy02
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,144] [PegaProx_dev] INFO: Executing: dpkg -s needrestart
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,214] [PegaProx_dev] INFO: Package needrestart is installed on node: de-fra03-dev-gyptazy02
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,215] [PegaProx_dev] INFO: Validate if node de-fra03-dev-gyptazy02 requires a restart (needrestart utility mode)
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,215] [PegaProx_dev] INFO: Executing: needrestart -p
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,398] [PegaProx_dev] INFO: Node de-fra03-dev-gyptazy02 requires a restart (needrestart utility mode)
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:36,398] [PegaProx_dev] INFO: Sending reboot command to de-fra03-dev-gyptazy02 (root=True)
Aug 17 07:27:36 de-fra03-dev-gyptazy01 pegaprox[288937]: Socket exception: Connection reset by peer (104)
Aug 17 07:27:39 de-fra03-dev-gyptazy01 pegaprox[288937]: [2026-08-17 07:27:39,453] [PegaProx_dev] INFO: Waiting for de-fra03-dev-gyptazy02 to come back online (timeout: 600s)...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rolling-update reboot handling by determining whether a system restart is necessary before proceeding.
  * Prevented unnecessary reboots when no restart is required.
  * Added a reliable fallback to perform the reboot when restart-status checks are unavailable.
  * Added clearer update logging before evaluating reboot requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Reboot nodes only when patching confirms that a restart is required

### What Changed
- After package updates, nodes with `needrestart` installed are checked before rebooting
- Nodes that do not require a restart now skip the reboot and show this outcome in the update output
- Nodes without `needrestart` continue with the reboot to avoid missing required restarts
- Update logs now show when reboot requirements are being evaluated

### Impact
`✅ Fewer unnecessary node reboots`
`✅ Clearer patching progress and reboot decisions`
`✅ Required restarts remain covered on nodes without needrestart`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
