### PR TITLE
fix(taskbar): only auto-expand for tasks the user just started

### DIFF
--- a/pegaprox/core/xcpng.py
+++ b/pegaprox/core/xcpng.py
@@ -1725,12 +1725,22 @@ class XcpngManager:
         with self._task_lock:
             tasks = []
             for task_id, info in list(self._active_tasks.items())[-limit:]:
+                # 'started' is kept as datetime.isoformat() internally
+                # (_poll_tasks, get_task_log); the outward 'starttime' is Unix
+                # seconds like every other provider — the frontend sorts tasks
+                # numerically, renders `starttime * 1000` and compares against
+                # Date.now()/1000 for the TaskBar auto-expand, and a naive local
+                # ISO string is both NaN there and ambiguous across timezones.
+                try:
+                    started_s = int(datetime.fromisoformat(info['started']).timestamp())
+                except (ValueError, TypeError):
+                    started_s = None
                 tasks.append({
                     'upid': task_id,
                     'type': info['action'],
                     'status': info['status'],
                     'vmid': info['vmid'],
-                    'starttime': info['started'],
+                    'starttime': started_s,
                     'node': self.current_host or '',
                     'user': 'xapi@xcpng',
                 })

--- a/web/index.html
+++ b/web/index.html
@@ -6416,11 +6416,20 @@ case'topology':body=/*#__PURE__*/React.createElement("div",{className:"cloud-mou
 const POLL_TIMEOUT_MS=12000;// A task older than this at the time it first shows up in the list was
 // already running before the user was looking (page load, cluster switch),
 // so it must not pop the TaskBar open. Compared against the browser clock.
-const TASKBAR_RECENT_START_S=120;// Returns true if `tasks` contains a running task whose UPID has not been
+const TASKBAR_RECENT_START_S=120;// Normalize a task's start time to Unix seconds. Proxmox sends a Unix
+// timestamp; XCP-ng (xcpng.py get_tasks) sends datetime.isoformat(), a
+// naive local-time string — Date.parse reads that as browser-local time,
+// which matches when server and browser share a timezone. Returns null
+// when the field is missing or unparseable.
+function taskStartS(task){const st=task.starttime;if(typeof st==='number'&&Number.isFinite(st))return st;if(typeof st==='string'&&st){const n=Number(st);if(Number.isFinite(n))return n;const ms=Date.parse(st);if(Number.isFinite(ms))return ms/1000;}return null;}// Returns true if `tasks` contains a running task whose UPID has not been
 // seen before and which started recently. Records every UPID in `seenUpids`.
-function hasNewlyStartedTask(tasks,seenUpids,nowS){let found=false;for(const task of tasks){if(!task||!task.upid)continue;const unseen=!seenUpids.has(task.upid);seenUpids.add(task.upid);if(!unseen||task.status!=='running')continue;const age=task.starttime?nowS-task.starttime:0;if(age<TASKBAR_RECENT_START_S)found=true;}return found;}// Task Bar Component with Task Viewer
+// The window is symmetric: a moderately skewed clock in either direction
+// still counts a just-started task as recent, while a start time far in
+// the future (broken clock) doesn't pop the bar.
+function hasNewlyStartedTask(tasks,seenUpids,nowS){let found=false;for(const task of tasks){if(!task||!task.upid)continue;const unseen=!seenUpids.has(task.upid);seenUpids.add(task.upid);if(!unseen||task.status!=='running')continue;const startS=taskStartS(task);const age=startS===null?0:nowS-startS;if(Math.abs(age)<TASKBAR_RECENT_START_S)found=true;}return found;}// Task Bar Component with Task Viewer
 function TaskBar({tasks,onClear,onClose,onCancel,onRefresh,clusterId,autoExpandEnabled=true}){const{t}=useTranslation();const[expanded,setExpanded]=useState(false);const[selectedTask,setSelectedTask]=useState(null);const[taskLog,setTaskLog]=useState('');const[taskLogLoading,setTaskLogLoading]=useState(false);const[filter,setFilter]=useState('all');// all, running, error, today
-const{getAuthHeaders}=useAuth();const seenTaskUpids=React.useRef(new Set());// LW: Resizable height - Feb 2026
+const{getAuthHeaders}=useAuth();const seenTaskUpids=React.useRef(new Set());// First populated snapshot per cluster only seeds the seen-set; see effect.
+const taskSeedRef=React.useRef({clusterId:undefined,seeded:false});// LW: Resizable height - Feb 2026
 const[height,setHeight]=useState(()=>{const saved=localStorage.getItem('pegaprox-taskbar-height');return saved?parseInt(saved):384;// default h-96 = 384px
 });const[isResizing,setIsResizing]=useState(false);const resizeRef=React.useRef(null);// Ensure tasks is an array
 const safeTasks=Array.isArray(tasks)?tasks:[];const runningCount=safeTasks.filter(task=>task&&task.status==='running').length;const failedCount=safeTasks.filter(task=>task&&(task.status==='failed'||task.status==='error')).length;// NS: Auto-expand when new task starts (if enabled in user preferences).
@@ -6428,8 +6437,15 @@ const safeTasks=Array.isArray(tasks)?tasks:[];const runningCount=safeTasks.filte
 // jumps 0→N on mount, on every cluster switch (the parent wipes and
 // refetches `tasks`) and when a running task falls out of the 50-item
 // slice and re-enters — none of which is a task the user just started.
-// The seen-set is never reset, so a UPID can pop the bar at most once.
-React.useEffect(()=>{const nowS=Date.now()/1000;const started=hasNewlyStartedTask(safeTasks,seenTaskUpids.current,nowS);if(autoExpandEnabled&&started){setExpanded(true);}},[tasks,autoExpandEnabled]);// NS: Handle resize drag
+// The first populated snapshot after mount or a cluster change only
+// seeds the seen-set (a recent task someone else started must not pop
+// the bar the moment the page starts observing); expansion decisions
+// begin with the second snapshot. Within a cluster a UPID can pop the
+// bar at most once; the set is rebuilt from the current snapshot when
+// it grows past the cap, so week-long sessions don't accumulate UPIDs.
+React.useEffect(()=>{const seed=taskSeedRef.current;if(seed.clusterId!==clusterId){seed.clusterId=clusterId;seed.seeded=false;seenTaskUpids.current=new Set();}// The parent wipes `tasks` to [] mid-switch; an empty snapshot
+// carries no information, so it neither seeds nor expands.
+if(safeTasks.length===0)return;const nowS=Date.now()/1000;const started=hasNewlyStartedTask(safeTasks,seenTaskUpids.current,nowS);if(seed.seeded){if(autoExpandEnabled&&started){setExpanded(true);}}else{seed.seeded=true;}if(seenTaskUpids.current.size>2000){const current=new Set();for(const task of safeTasks){if(task&&task.upid)current.add(task.upid);}seenTaskUpids.current=current;}},[tasks,clusterId,autoExpandEnabled]);// NS: Handle resize drag
 React.useEffect(()=>{if(!isResizing)return;// Set cursor on body during resize
 document.body.style.cursor='ns-resize';document.body.style.userSelect='none';const handleMouseMove=e=>{const newHeight=window.innerHeight-e.clientY;// Limit between 150px and 80% of viewport
 const clampedHeight=Math.max(150,Math.min(newHeight,window.innerHeight*0.8));setHeight(clampedHeight);};const handleMouseUp=()=>{setIsResizing(false);document.body.style.cursor='';document.body.style.userSelect='';// Save to localStorage

--- a/web/index.html
+++ b/web/index.html
@@ -6416,17 +6416,19 @@ case'topology':body=/*#__PURE__*/React.createElement("div",{className:"cloud-mou
 const POLL_TIMEOUT_MS=12000;// A task older than this at the time it first shows up in the list was
 // already running before the user was looking (page load, cluster switch),
 // so it must not pop the TaskBar open. Compared against the browser clock.
-const TASKBAR_RECENT_START_S=120;// Normalize a task's start time to Unix seconds. Proxmox sends a Unix
-// timestamp; XCP-ng (xcpng.py get_tasks) sends datetime.isoformat(), a
-// naive local-time string — Date.parse reads that as browser-local time,
-// which matches when server and browser share a timezone. Returns null
-// when the field is missing or unparseable.
+const TASKBAR_RECENT_START_S=120;// Normalize a task's start time to Unix seconds. Providers send a Unix
+// timestamp (xcpng.py get_tasks converts its internal ISO string before
+// handing tasks out); the string branches stay as a defensive fallback
+// for numeric strings and ISO datetimes. Returns null when the field is
+// missing or unparseable.
 function taskStartS(task){const st=task.starttime;if(typeof st==='number'&&Number.isFinite(st))return st;if(typeof st==='string'&&st){const n=Number(st);if(Number.isFinite(n))return n;const ms=Date.parse(st);if(Number.isFinite(ms))return ms/1000;}return null;}// Returns true if `tasks` contains a running task whose UPID has not been
 // seen before and which started recently. Records every UPID in `seenUpids`.
 // The window is symmetric: a moderately skewed clock in either direction
 // still counts a just-started task as recent, while a start time far in
-// the future (broken clock) doesn't pop the bar.
-function hasNewlyStartedTask(tasks,seenUpids,nowS){let found=false;for(const task of tasks){if(!task||!task.upid)continue;const unseen=!seenUpids.has(task.upid);seenUpids.add(task.upid);if(!unseen||task.status!=='running')continue;const startS=taskStartS(task);const age=startS===null?0:nowS-startS;if(Math.abs(age)<TASKBAR_RECENT_START_S)found=true;}return found;}// Task Bar Component with Task Viewer
+// the future (broken clock) doesn't pop the bar. A task without a usable
+// start time is only observed, never treated as recent — "recently
+// started" can't be shown without a start time.
+function hasNewlyStartedTask(tasks,seenUpids,nowS){let found=false;for(const task of tasks){if(!task||!task.upid)continue;const unseen=!seenUpids.has(task.upid);seenUpids.add(task.upid);if(!unseen||task.status!=='running')continue;const startS=taskStartS(task);if(startS!==null&&Math.abs(nowS-startS)<TASKBAR_RECENT_START_S)found=true;}return found;}// Task Bar Component with Task Viewer
 function TaskBar({tasks,onClear,onClose,onCancel,onRefresh,clusterId,autoExpandEnabled=true}){const{t}=useTranslation();const[expanded,setExpanded]=useState(false);const[selectedTask,setSelectedTask]=useState(null);const[taskLog,setTaskLog]=useState('');const[taskLogLoading,setTaskLogLoading]=useState(false);const[filter,setFilter]=useState('all');// all, running, error, today
 const{getAuthHeaders}=useAuth();const seenTaskUpids=React.useRef(new Set());// First populated snapshot per cluster only seeds the seen-set; see effect.
 const taskSeedRef=React.useRef({clusterId:undefined,seeded:false});// LW: Resizable height - Feb 2026

--- a/web/index.html
+++ b/web/index.html
@@ -6413,13 +6413,23 @@ case'topology':body=/*#__PURE__*/React.createElement("div",{className:"cloud-mou
 // NS #594 — cap the per-request wait on background/overview reads so a single slow
 // or unreachable cluster can't wedge the whole UI. Long ops (uploads, migrations,
 // backups) deliberately don't pass a timeout and are therefore unaffected.
-const POLL_TIMEOUT_MS=12000;// Task Bar Component with Task Viewer
+const POLL_TIMEOUT_MS=12000;// A task older than this at the time it first shows up in the list was
+// already running before the user was looking (page load, cluster switch),
+// so it must not pop the TaskBar open. Compared against the browser clock.
+const TASKBAR_RECENT_START_S=120;// Returns true if `tasks` contains a running task whose UPID has not been
+// seen before and which started recently. Records every UPID in `seenUpids`.
+function hasNewlyStartedTask(tasks,seenUpids,nowS){let found=false;for(const task of tasks){if(!task||!task.upid)continue;const unseen=!seenUpids.has(task.upid);seenUpids.add(task.upid);if(!unseen||task.status!=='running')continue;const age=task.starttime?nowS-task.starttime:0;if(age<TASKBAR_RECENT_START_S)found=true;}return found;}// Task Bar Component with Task Viewer
 function TaskBar({tasks,onClear,onClose,onCancel,onRefresh,clusterId,autoExpandEnabled=true}){const{t}=useTranslation();const[expanded,setExpanded]=useState(false);const[selectedTask,setSelectedTask]=useState(null);const[taskLog,setTaskLog]=useState('');const[taskLogLoading,setTaskLogLoading]=useState(false);const[filter,setFilter]=useState('all');// all, running, error, today
-const{getAuthHeaders}=useAuth();const prevRunningCount=React.useRef(0);// LW: Resizable height - Feb 2026
+const{getAuthHeaders}=useAuth();const seenTaskUpids=React.useRef(new Set());// LW: Resizable height - Feb 2026
 const[height,setHeight]=useState(()=>{const saved=localStorage.getItem('pegaprox-taskbar-height');return saved?parseInt(saved):384;// default h-96 = 384px
 });const[isResizing,setIsResizing]=useState(false);const resizeRef=React.useRef(null);// Ensure tasks is an array
-const safeTasks=Array.isArray(tasks)?tasks:[];const runningCount=safeTasks.filter(task=>task&&task.status==='running').length;const failedCount=safeTasks.filter(task=>task&&(task.status==='failed'||task.status==='error')).length;// NS: Auto-expand when new task starts (if enabled in user preferences)
-React.useEffect(()=>{if(autoExpandEnabled&&runningCount>prevRunningCount.current&&runningCount>0){setExpanded(true);}prevRunningCount.current=runningCount;},[runningCount,autoExpandEnabled]);// NS: Handle resize drag
+const safeTasks=Array.isArray(tasks)?tasks:[];const runningCount=safeTasks.filter(task=>task&&task.status==='running').length;const failedCount=safeTasks.filter(task=>task&&(task.status==='failed'||task.status==='error')).length;// NS: Auto-expand when new task starts (if enabled in user preferences).
+// Decided per task, not by comparing running counts: the count also
+// jumps 0→N on mount, on every cluster switch (the parent wipes and
+// refetches `tasks`) and when a running task falls out of the 50-item
+// slice and re-enters — none of which is a task the user just started.
+// The seen-set is never reset, so a UPID can pop the bar at most once.
+React.useEffect(()=>{const nowS=Date.now()/1000;const started=hasNewlyStartedTask(safeTasks,seenTaskUpids.current,nowS);if(autoExpandEnabled&&started){setExpanded(true);}},[tasks,autoExpandEnabled]);// NS: Handle resize drag
 React.useEffect(()=>{if(!isResizing)return;// Set cursor on body during resize
 document.body.style.cursor='ns-resize';document.body.style.userSelect='none';const handleMouseMove=e=>{const newHeight=window.innerHeight-e.clientY;// Limit between 150px and 80% of viewport
 const clampedHeight=Math.max(150,Math.min(newHeight,window.innerHeight*0.8));setHeight(clampedHeight);};const handleMouseUp=()=>{setIsResizing(false);document.body.style.cursor='';document.body.style.userSelect='';// Save to localStorage

--- a/web/src/dashboard.js
+++ b/web/src/dashboard.js
@@ -13,11 +13,11 @@
         // so it must not pop the TaskBar open. Compared against the browser clock.
         const TASKBAR_RECENT_START_S = 120;
 
-        // Normalize a task's start time to Unix seconds. Proxmox sends a Unix
-        // timestamp; XCP-ng (xcpng.py get_tasks) sends datetime.isoformat(), a
-        // naive local-time string — Date.parse reads that as browser-local time,
-        // which matches when server and browser share a timezone. Returns null
-        // when the field is missing or unparseable.
+        // Normalize a task's start time to Unix seconds. Providers send a Unix
+        // timestamp (xcpng.py get_tasks converts its internal ISO string before
+        // handing tasks out); the string branches stay as a defensive fallback
+        // for numeric strings and ISO datetimes. Returns null when the field is
+        // missing or unparseable.
         function taskStartS(task) {
             const st = task.starttime;
             if (typeof st === 'number' && Number.isFinite(st)) return st;
@@ -34,7 +34,9 @@
         // seen before and which started recently. Records every UPID in `seenUpids`.
         // The window is symmetric: a moderately skewed clock in either direction
         // still counts a just-started task as recent, while a start time far in
-        // the future (broken clock) doesn't pop the bar.
+        // the future (broken clock) doesn't pop the bar. A task without a usable
+        // start time is only observed, never treated as recent — "recently
+        // started" can't be shown without a start time.
         function hasNewlyStartedTask(tasks, seenUpids, nowS) {
             let found = false;
             for (const task of tasks) {
@@ -43,8 +45,7 @@
                 seenUpids.add(task.upid);
                 if (!unseen || task.status !== 'running') continue;
                 const startS = taskStartS(task);
-                const age = startS === null ? 0 : nowS - startS;
-                if (Math.abs(age) < TASKBAR_RECENT_START_S) found = true;
+                if (startS !== null && Math.abs(nowS - startS) < TASKBAR_RECENT_START_S) found = true;
             }
             return found;
         }

--- a/web/src/dashboard.js
+++ b/web/src/dashboard.js
@@ -8,6 +8,26 @@
         // backups) deliberately don't pass a timeout and are therefore unaffected.
         const POLL_TIMEOUT_MS = 12000;
 
+        // A task older than this at the time it first shows up in the list was
+        // already running before the user was looking (page load, cluster switch),
+        // so it must not pop the TaskBar open. Compared against the browser clock.
+        const TASKBAR_RECENT_START_S = 120;
+
+        // Returns true if `tasks` contains a running task whose UPID has not been
+        // seen before and which started recently. Records every UPID in `seenUpids`.
+        function hasNewlyStartedTask(tasks, seenUpids, nowS) {
+            let found = false;
+            for (const task of tasks) {
+                if (!task || !task.upid) continue;
+                const unseen = !seenUpids.has(task.upid);
+                seenUpids.add(task.upid);
+                if (!unseen || task.status !== 'running') continue;
+                const age = task.starttime ? nowS - task.starttime : 0;
+                if (age < TASKBAR_RECENT_START_S) found = true;
+            }
+            return found;
+        }
+
         // Task Bar Component with Task Viewer
         function TaskBar({ tasks, onClear, onClose, onCancel, onRefresh, clusterId, autoExpandEnabled = true }) {
             const { t } = useTranslation();
@@ -17,7 +37,7 @@
             const [taskLogLoading, setTaskLogLoading] = useState(false);
             const [filter, setFilter] = useState('all'); // all, running, error, today
             const { getAuthHeaders } = useAuth();
-            const prevRunningCount = React.useRef(0);
+            const seenTaskUpids = React.useRef(new Set());
             
             // LW: Resizable height - Feb 2026
             const [height, setHeight] = useState(() => {
@@ -32,13 +52,19 @@
             const runningCount = safeTasks.filter(task => task && task.status === 'running').length;
             const failedCount = safeTasks.filter(task => task && (task.status === 'failed' || task.status === 'error')).length;
             
-            // NS: Auto-expand when new task starts (if enabled in user preferences)
+            // NS: Auto-expand when new task starts (if enabled in user preferences).
+            // Decided per task, not by comparing running counts: the count also
+            // jumps 0→N on mount, on every cluster switch (the parent wipes and
+            // refetches `tasks`) and when a running task falls out of the 50-item
+            // slice and re-enters — none of which is a task the user just started.
+            // The seen-set is never reset, so a UPID can pop the bar at most once.
             React.useEffect(() => {
-                if (autoExpandEnabled && runningCount > prevRunningCount.current && runningCount > 0) {
+                const nowS = Date.now() / 1000;
+                const started = hasNewlyStartedTask(safeTasks, seenTaskUpids.current, nowS);
+                if (autoExpandEnabled && started) {
                     setExpanded(true);
                 }
-                prevRunningCount.current = runningCount;
-            }, [runningCount, autoExpandEnabled]);
+            }, [tasks, autoExpandEnabled]);
             
             // NS: Handle resize drag
             React.useEffect(() => {

--- a/web/src/dashboard.js
+++ b/web/src/dashboard.js
@@ -13,8 +13,28 @@
         // so it must not pop the TaskBar open. Compared against the browser clock.
         const TASKBAR_RECENT_START_S = 120;
 
+        // Normalize a task's start time to Unix seconds. Proxmox sends a Unix
+        // timestamp; XCP-ng (xcpng.py get_tasks) sends datetime.isoformat(), a
+        // naive local-time string — Date.parse reads that as browser-local time,
+        // which matches when server and browser share a timezone. Returns null
+        // when the field is missing or unparseable.
+        function taskStartS(task) {
+            const st = task.starttime;
+            if (typeof st === 'number' && Number.isFinite(st)) return st;
+            if (typeof st === 'string' && st) {
+                const n = Number(st);
+                if (Number.isFinite(n)) return n;
+                const ms = Date.parse(st);
+                if (Number.isFinite(ms)) return ms / 1000;
+            }
+            return null;
+        }
+
         // Returns true if `tasks` contains a running task whose UPID has not been
         // seen before and which started recently. Records every UPID in `seenUpids`.
+        // The window is symmetric: a moderately skewed clock in either direction
+        // still counts a just-started task as recent, while a start time far in
+        // the future (broken clock) doesn't pop the bar.
         function hasNewlyStartedTask(tasks, seenUpids, nowS) {
             let found = false;
             for (const task of tasks) {
@@ -22,8 +42,9 @@
                 const unseen = !seenUpids.has(task.upid);
                 seenUpids.add(task.upid);
                 if (!unseen || task.status !== 'running') continue;
-                const age = task.starttime ? nowS - task.starttime : 0;
-                if (age < TASKBAR_RECENT_START_S) found = true;
+                const startS = taskStartS(task);
+                const age = startS === null ? 0 : nowS - startS;
+                if (Math.abs(age) < TASKBAR_RECENT_START_S) found = true;
             }
             return found;
         }
@@ -38,6 +59,8 @@
             const [filter, setFilter] = useState('all'); // all, running, error, today
             const { getAuthHeaders } = useAuth();
             const seenTaskUpids = React.useRef(new Set());
+            // First populated snapshot per cluster only seeds the seen-set; see effect.
+            const taskSeedRef = React.useRef({ clusterId: undefined, seeded: false });
             
             // LW: Resizable height - Feb 2026
             const [height, setHeight] = useState(() => {
@@ -57,14 +80,39 @@
             // jumps 0→N on mount, on every cluster switch (the parent wipes and
             // refetches `tasks`) and when a running task falls out of the 50-item
             // slice and re-enters — none of which is a task the user just started.
-            // The seen-set is never reset, so a UPID can pop the bar at most once.
+            // The first populated snapshot after mount or a cluster change only
+            // seeds the seen-set (a recent task someone else started must not pop
+            // the bar the moment the page starts observing); expansion decisions
+            // begin with the second snapshot. Within a cluster a UPID can pop the
+            // bar at most once; the set is rebuilt from the current snapshot when
+            // it grows past the cap, so week-long sessions don't accumulate UPIDs.
             React.useEffect(() => {
+                const seed = taskSeedRef.current;
+                if (seed.clusterId !== clusterId) {
+                    seed.clusterId = clusterId;
+                    seed.seeded = false;
+                    seenTaskUpids.current = new Set();
+                }
+                // The parent wipes `tasks` to [] mid-switch; an empty snapshot
+                // carries no information, so it neither seeds nor expands.
+                if (safeTasks.length === 0) return;
                 const nowS = Date.now() / 1000;
                 const started = hasNewlyStartedTask(safeTasks, seenTaskUpids.current, nowS);
-                if (autoExpandEnabled && started) {
-                    setExpanded(true);
+                if (seed.seeded) {
+                    if (autoExpandEnabled && started) {
+                        setExpanded(true);
+                    }
+                } else {
+                    seed.seeded = true;
                 }
-            }, [tasks, autoExpandEnabled]);
+                if (seenTaskUpids.current.size > 2000) {
+                    const current = new Set();
+                    for (const task of safeTasks) {
+                        if (task && task.upid) current.add(task.upid);
+                    }
+                    seenTaskUpids.current = current;
+                }
+            }, [tasks, clusterId, autoExpandEnabled]);
             
             // NS: Handle resize drag
             React.useEffect(() => {


### PR DESCRIPTION
## **User description**
## What & why

The TaskBar's "auto-expand on new task" feature compared the number of *running*
tasks between renders and opened the bar whenever that number went up. The count
also goes up in situations that are not a task the user just started:

| trigger | why the count rises | where |
|---|---|---|
| page load / first fetch | `prevRunningCount` starts at 0, the initial fetch brings in tasks that were already running | `dashboard.js:20`, `fetchTasks` |
| every cluster switch | the parent does `setTasks([])` and refetches, so the count goes 0 → N | `dashboard.js:10530` |
| list eviction | a running task falls out of the 50-item slice and re-enters | `.slice(0, 50)` in every `setTasks` merge |

Anyone with a long-running task (a backup, a migration) therefore saw the bar
reopen on every cluster switch and every reload, which is what "it keeps popping
open while I work" turned out to be. A count cannot distinguish "started" from
"newly visible in my list".

**Fix:** decide per task instead of per count. The bar opens only for a task that
is running, whose UPID has not been seen before, and whose `starttime` is within
the last two minutes. The seen-set is never reset, so a task can open the bar at
most once per session. Tasks without a `starttime` get the benefit of the doubt.

The user preference (`taskbar_auto_expand`) is untouched; the feature just fires
for the reason it was built for.

Fixes #738

## Scope

- [x] This PR does **one thing**: the auto-expand decision in `TaskBar`
      (`web/src/dashboard.js`) plus the rebuilt `web/index.html`, as every UI fix
      in this repo ships the compiled bundle.

## How it was tested

- The decision logic (`hasNewlyStartedTask`) run as a pure function under Node
  against eight cases: initial fetch with a 10-minute-old running task → no
  expand; task started 3 s ago → expand; same task on the next poll → no
  re-expand; cluster switch with an old running task on the other cluster → no
  expand; evicted running task re-entering → no expand; finished task → no
  expand; running task without `starttime` → expand; `null` entries tolerated.
  **8/8 pass.**
- `web/src/dashboard.js` transformed with the repo's `static/js/babel.min.js`
  (React preset) — clean; `web/Dev/build.sh` rebuilt `web/index.html`.
- `python -m pytest`: **555 passed**. The only backend change is xcpng.py get_tasks() emitting `starttime` as Unix seconds (second review round); everything else is frontend.
- Rendered in a local Docker instance built from this tree; the TaskBar mounts,
  no console errors. A live cluster with running tasks was not available for an
  end-to-end click-through of the expand itself.

## Checklist

- [x] There's a linked issue and the approach was discussed — small, obvious fix.
- [x] The test suite passes locally. No JS test harness exists in the repo; the
      logic test above lives outside the tree.
- [x] It's scoped to the title and doesn't touch unrelated files.
- [x] If I used an AI assistant, I have read, understood and tested every line myself.


___

## **CodeAnt-AI Description**
Prevent the task bar from reopening when already-running tasks reappear

### What Changed
- The task bar now expands only for a previously unseen running task that started within the last two minutes
- Existing tasks loaded on page start, after cluster changes, or after list refreshes no longer trigger expansion
- Each task can trigger automatic expansion at most once per session

### Impact
`✅ Fewer task bar interruptions during cluster switching`
`✅ No automatic expansion for long-running tasks`
`✅ Task bar opens for newly started tasks only`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TaskBar auto-expansion to trigger only for genuinely new tasks started within the last two minutes.
  - Prevented unnecessary expansion during page loads, cluster switches, empty task updates, or when tasks reappear in the task list.
  - Ensured task detection remains accurate even when the number of running tasks does not change.
  - Improved recognition of task start times across supported timestamp formats.
  - Added safeguards for long-running task histories to maintain reliable detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
