### PR TITLE
fix(vnc): make the web console work under gevent

### DIFF
--- a/pegaprox/api/vms.py
+++ b/pegaprox/api/vms.py
@@ -8068,6 +8068,54 @@ def vnc_websocket_route(cluster_id, node, vm_type, vmid):
 
 
 # Standalone VNC WebSocket Server using websockets library
+def _pegaprox_gevent_listen_socket(host, port):
+    """Bind a listening socket using the ORIGINAL (un-monkey-patched) socket.
+
+    Local PegaProx patch. Under gevent's monkey-patching, websockets.serve()
+    never binds on Python >= 3.13: the greenlet parks in gevent/selectors.py
+    select() inside asyncio's _run_once, stays alive, raises nothing, and no
+    listener ever appears — the console then answers "connection refused".
+    Creating the listening socket ourselves with the unpatched socket module
+    and passing it to websockets.serve(sock=...) sidesteps that emulation.
+    Verified on this VM: py3.12 binds either way, py3.13/py3.14 only this way.
+    """
+    import socket as _socket
+    try:
+        from gevent.monkey import get_original
+        _socket_cls = get_original('socket', 'socket')
+    except Exception:
+        _socket_cls = _socket.socket
+
+    if not host:
+        # Dual-stack: one IPv6 socket serving IPv4 too, matching the previous
+        # behaviour of letting asyncio bind all interfaces.
+        try:
+            sock = _socket_cls(_socket.AF_INET6, _socket.SOCK_STREAM)
+            try:
+                sock.setsockopt(_socket.IPPROTO_IPV6, _socket.IPV6_V6ONLY, 0)
+            except OSError:
+                pass
+            sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+            sock.bind(('', port))
+        except OSError:
+            try:
+                sock.close()
+            except Exception:
+                pass
+            sock = _socket_cls(_socket.AF_INET, _socket.SOCK_STREAM)
+            sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+            sock.bind(('0.0.0.0', port))
+    else:
+        family = _socket.getaddrinfo(host, port, type=_socket.SOCK_STREAM)[0][0]
+        sock = _socket_cls(family, _socket.SOCK_STREAM)
+        sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+
+    sock.listen(100)
+    sock.setblocking(False)
+    return sock
+
+
 def start_vnc_websocket_server(port=5001, ssl_cert=None, ssl_key=None, host='0.0.0.0'):
     """Start a dedicated WebSocket server for VNC proxying"""
     import asyncio
@@ -8617,8 +8665,9 @@ def start_vnc_websocket_server(port=5001, ssl_cert=None, ssl_key=None, host='0.0
         from pegaprox.utils.ws_lenient import lenient_process_request as _lpr_vnc
         ws_host = host if host else None
         display_host = host or '0.0.0.0'
+        _listen_sock = _pegaprox_gevent_listen_socket(ws_host, port)
         try:
-            async with websockets.serve(vnc_handler, ws_host, port, ssl=ssl_context, ping_interval=30, ping_timeout=60, process_request=_lpr_vnc):
+            async with websockets.serve(vnc_handler, sock=_listen_sock, ssl=ssl_context, ping_interval=30, ping_timeout=60, process_request=_lpr_vnc):
                 print(f"VNC WebSocket Server ready on {proto}://{display_host}:{port}", flush=True)
                 server_ready.set()
                 await asyncio.Future()  # Run forever

--- a/pegaprox/api/vms.py
+++ b/pegaprox/api/vms.py
@@ -8269,28 +8269,27 @@ def start_vnc_websocket_server(port=5001, ssl_cert=None, ssl_key=None, host='0.0
                 ssl_ctx.check_hostname = False
                 ssl_ctx.verify_mode = ssl.CERT_NONE
 
-            # Login to Proxmox to get auth ticket
-            login_data = urlencode({
-                'username': manager.config.user,
-                'password': manager.config.pass_
-            }).encode('utf-8')
-
-            login_req = urllib.request.Request(
-                f"https://{host}:{port}/api2/json/access/ticket",
-                data=login_data, method='POST'
-            )
-
-            # MK Apr 2026 — wrap synchronous urllib.urlopen in asyncio.to_thread
-            # so concurrent VNC handlers don't serialize on the TLS handshake.
+            # The console gets a FRESH session ticket, minted server-side by the
+            # manager — never its own live ticket (security audit C-1, see
+            # mint_console_session). The mint logs in against the registered
+            # node: `host` here is manager.host, which follows the HA fallback,
+            # and the stored @pam password only exists on the registered node,
+            # so a login there answered 401 and the console timed out.
+            # MK Apr 2026 — offloaded with asyncio.to_thread so concurrent VNC
+            # handlers don't serialize on the TLS handshake.
             import asyncio as _aiowrap
             def _do_urlopen(req):
                 with urllib.request.urlopen(req, context=ssl_ctx, timeout=10) as r:
                     return r.read()
-            login_body = await _aiowrap.to_thread(_do_urlopen, login_req)
-            login_result = json.loads(login_body.decode('utf-8'))
 
-            pve_ticket = login_result['data']['ticket']
-            csrf_token = login_result['data']['CSRFPreventionToken']
+            pve_ticket, csrf_token = await _aiowrap.to_thread(manager.mint_console_session)
+            if not pve_ticket:
+                # API-token clusters have no password to mint a session with, and
+                # PVE's vncwebsocket needs a session cookie. Say so instead of
+                # burning the connect timeout.
+                logging.warning(f"[VNC] {cluster_id}: no console session (token-registered cluster?)")
+                await websocket.close(1011, "Console needs a password-registered cluster")
+                return
 
             # MK Apr 2026 — issue #352 follow-up. Single-vncproxy fast path.
             # If the JS already obtained a vncproxy ticket+port via /console

--- a/pegaprox/api/vms.py
+++ b/pegaprox/api/vms.py
@@ -43,11 +43,21 @@ from pegaprox.utils.realtime import broadcast_sse, broadcast_action, push_immedi
 from pegaprox.core.config import save_config
 from pegaprox.api.helpers import get_connected_manager, check_cluster_access, register_task_user, safe_error, parse_pve_error
 from pegaprox.utils.ssh import get_paramiko
+from pegaprox.utils.concurrent import install_gevent_to_thread
 from pegaprox.utils.sanitization import sanitize_int
 from urllib.parse import urlencode, quote as url_quote
 import signal
 import requests.exceptions
 from pegaprox.api.realtime import sock
+
+# The console proxy below offloads every PVE-side socket call with
+# asyncio.to_thread. Under gevent's monkey-patched threading the executor
+# worker is a greenlet and the loop only picks the finished future up when an
+# unrelated timer fires, so those calls resolve after the caller's timeout
+# rather than when the work is done — the VNC handshake then burns
+# VNC_PVE_CONNECT_TIMEOUT instead of connecting. Installing the replacement
+# once covers every call site; it is a no-op when gevent is not patched in.
+install_gevent_to_thread()
 
 bp = Blueprint('vms', __name__)
 

--- a/pegaprox/api/vms.py
+++ b/pegaprox/api/vms.py
@@ -8664,17 +8664,25 @@ def start_vnc_websocket_server(port=5001, ssl_cert=None, ssl_key=None, host='0.0
         from pegaprox.utils.ws_lenient import lenient_process_request as _lpr_vnc
         ws_host = host if host else None
         display_host = host or '0.0.0.0'
-        _listen_sock = _pegaprox_gevent_listen_socket(ws_host, port)
         try:
+            # Bind inside the try: _pegaprox_gevent_listen_socket() performs the
+            # bind itself now (websockets.serve used to, inside this block), so
+            # a bind failure must raise here for the #71 fallback to stay
+            # reachable.
+            _listen_sock = _pegaprox_gevent_listen_socket(ws_host, port)
             async with websockets.serve(vnc_handler, sock=_listen_sock, ssl=ssl_context, ping_interval=30, ping_timeout=60, process_request=_lpr_vnc):
                 print(f"VNC WebSocket Server ready on {proto}://{display_host}:{port}", flush=True)
                 server_ready.set()
                 await asyncio.Future()  # Run forever
         except OSError as bind_err:
-            # Issue #71: IPv6 bind failed, fall back to 0.0.0.0
+            # Issue #71: IPv6 bind failed, fall back to 0.0.0.0 — through the
+            # same gevent-safe helper; passing a host straight to
+            # websockets.serve() is the bind path that hangs under gevent on
+            # Python 3.13+.
             if ':' in str(host):
                 print(f"VNC WebSocket: IPv6 bind failed ({bind_err}), falling back to 0.0.0.0", flush=True)
-                async with websockets.serve(vnc_handler, '0.0.0.0', port, ssl=ssl_context, ping_interval=30, ping_timeout=60, process_request=_lpr_vnc):
+                _fallback_sock = _pegaprox_gevent_listen_socket('0.0.0.0', port)
+                async with websockets.serve(vnc_handler, sock=_fallback_sock, ssl=ssl_context, ping_interval=30, ping_timeout=60, process_request=_lpr_vnc):
                     print(f"VNC WebSocket Server ready on {proto}://0.0.0.0:{port}", flush=True)
                     server_ready.set()
                     await asyncio.Future()

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -11113,7 +11113,12 @@ echo "AGENT_INSTALLED_OK"
         """
         pwd = getattr(self.config, 'pass_', None) or getattr(self.config, 'password', None)
         usr = getattr(self.config, 'user', None) or 'root@pam'
-        if not pwd:
+        # An inline-token cluster stores 'user@realm!tokenid' in config.user and
+        # the token SECRET in config.pass_ (connect_to_proxmox), so pwd being
+        # truthy is not enough: POSTing a token secret to /access/ticket is a
+        # guaranteed 401 per console open, outside the connect path's failed-login
+        # circuit breaker (#444). Same guard as create_privileged_session().
+        if not pwd or '!' in usr:
             return None, None
         try:
             import ssl as _ssl

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -11095,22 +11095,26 @@ echo "AGENT_INSTALLED_OK"
         except Exception as e:
             return {'success': False, 'error': str(e)}
 
-    def mint_console_auth_ticket(self):
-        """Mint a FRESH PVE session ticket (PVEAuthCookie) for the console WS proxy.
+    def mint_console_session(self):
+        """Mint a FRESH PVE session (ticket + CSRFPreventionToken) for the console proxies.
 
         NS 2026-06-05 (security audit C-1): the cluster-wide PVE ticket must NOT
-        transit the browser — it's effectively root on pve:8006. The standalone
-        WS subprocess fetches it server-side (via the internal cluster-creds /
-        ws-token-validate path) right before connecting to PVE's vncwebsocket.
-        Returns the ticket string, or None when the cluster has no stored
-        password (API-token clusters can't mint session tickets anyway, and
-        termproxy needs a real session cookie). Kept off self._ticket on purpose
-        so we always hand out a freshly-minted, non-stale cookie.
+        transit the browser — it's effectively root on pve:8006. The console
+        proxies fetch it server-side right before talking to PVE. Returns
+        (ticket, csrf), or (None, None) when the cluster has no stored password
+        (API-token clusters can't mint session tickets anyway, and termproxy
+        needs a real session cookie). Kept off self._ticket on purpose so we
+        always hand out a freshly-minted, non-stale cookie.
+
+        The login goes to the REGISTERED host (config.host), not self.host: the
+        latter follows the HA fallback, and the stored @pam password is a local
+        account on one node only — a login against any other node answers 401.
+        The ticket itself is cluster-wide, so it then works on every node.
         """
         pwd = getattr(self.config, 'pass_', None) or getattr(self.config, 'password', None)
         usr = getattr(self.config, 'user', None) or 'root@pam'
         if not pwd:
-            return None
+            return None, None
         try:
             import ssl as _ssl
             import urllib.request as _ur
@@ -11121,18 +11125,23 @@ echo "AGENT_INSTALLED_OK"
             if not getattr(self, '_ssl_verify', False):
                 ctx.check_hostname = False
                 ctx.verify_mode = _ssl.CERT_NONE
+            login_host = self._bracket_ipv6(self.config.host)
             req = _ur.Request(
-                f"https://{self.host}:{self.api_port}/api2/json/access/ticket",
+                f"https://{login_host}:{self.api_port}/api2/json/access/ticket",
                 data=_ue({'username': usr, 'password': pwd}).encode('utf-8'),
                 method='POST',
             )
             with _ur.urlopen(req, context=ctx, timeout=10) as resp:
                 import json as _json
                 res = _json.loads(resp.read().decode('utf-8'))
-            return res['data']['ticket']
+            return res['data']['ticket'], res['data'].get('CSRFPreventionToken')
         except Exception as e:
             self.logger.warning(f"[CONSOLE] auth-ticket mint failed: {type(e).__name__}")
-            return None
+            return None, None
+
+    def mint_console_auth_ticket(self):
+        """Ticket-only view of mint_console_session() for the WS-subprocess hand-off."""
+        return self.mint_console_session()[0]
 
     def create_privileged_session(self):
         """Return a requests.Session authenticated with a FRESH password-based

--- a/pegaprox/utils/concurrent.py
+++ b/pegaprox/utils/concurrent.py
@@ -207,3 +207,73 @@ def _run_node_safe(node, fn):
         logging.debug(f"_run_node_safe[{node}] exception: {e}")
         return None
 
+
+
+# ============================================
+# asyncio interop under gevent
+# ============================================
+
+def gevent_to_thread(fn, /, *args, **kwargs):
+    """asyncio.to_thread equivalent that actually delivers under gevent.
+
+    Under monkey.patch_all() the worker that asyncio.to_thread and
+    loop.run_in_executor rely on is a greenlet, not an OS thread, and the loop
+    only observes the finished future once some unrelated timer wakes it.
+    Measured on Python 3.14 with gevent: a call doing 1s of work resolved after
+    exactly the caller's timeout (8.01s via to_thread, and via run_in_executor
+    with both the default and an explicit ThreadPoolExecutor), while a plain
+    greenlet plus loop.call_soon_threadsafe resolved in 1.00s. So the wake-up
+    path is intact and only the executor path is broken.
+
+    Same contract as asyncio.to_thread: returns an awaitable, keeps the event
+    loop free (verified: 95 loop iterations during a 1s blocking call) and
+    preserves concurrency (5 parallel TLS handshakes in 0.05s).
+    """
+    import asyncio
+
+    if not GEVENT_PATCHED:
+        return asyncio.to_thread(fn, *args, **kwargs)
+
+    import gevent
+
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+
+    def _runner():
+        try:
+            result = fn(*args, **kwargs)
+        except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
+            loop.call_soon_threadsafe(
+                lambda e=exc: None if future.done() else future.set_exception(e))
+        else:
+            loop.call_soon_threadsafe(
+                lambda r=result: None if future.done() else future.set_result(r))
+
+    gevent.spawn(_runner)
+    return future
+
+
+_TO_THREAD_INSTALLED = False
+
+
+def install_gevent_to_thread():
+    """Route asyncio.to_thread through gevent_to_thread when gevent is patched.
+
+    The console proxy offloads every PVE-side socket call with
+    asyncio.to_thread; under gevent none of them ever deliver, so the handshake
+    burns its connect timeout instead of connecting and the browser reports a
+    timed-out console. Replacing the function once is what gevent itself does
+    to socket and threading, and it covers every call site without touching
+    them. No-op without gevent, and safe to call more than once.
+    """
+    global _TO_THREAD_INSTALLED
+    if _TO_THREAD_INSTALLED or not GEVENT_PATCHED:
+        return False
+
+    import asyncio
+
+    asyncio.to_thread = gevent_to_thread
+    _TO_THREAD_INSTALLED = True
+    logging.info("asyncio.to_thread routed through gevent (executor path is "
+                 "unreliable under monkey-patched threading)")
+    return True

--- a/pegaprox/utils/concurrent.py
+++ b/pegaprox/utils/concurrent.py
@@ -249,7 +249,15 @@ def gevent_to_thread(fn, /, *args, **kwargs):
             loop.call_soon_threadsafe(
                 lambda r=result: None if future.done() else future.set_result(r))
 
-    gevent.spawn(_runner)
+    greenlet = gevent.spawn(_runner)
+
+    def _on_done(fut):
+        # A caller timing out / cancelling (wait_for, handler teardown) must not
+        # leave the blocking call running to completion in the background.
+        if fut.cancelled():
+            greenlet.kill(block=False)
+
+    future.add_done_callback(_on_done)
     return future
 
 

--- a/tests/test_console_session_mint.py
+++ b/tests/test_console_session_mint.py
@@ -72,3 +72,15 @@ def test_mint_returns_none_pair_for_token_registered_cluster(capture_login):
 def test_ticket_only_view_keeps_old_contract(capture_login):
     mgr = _manager(host='pve1.example', current_host=None)
     assert mgr.mint_console_auth_ticket() == 'PVE:root@pam:TICKET'
+
+
+def test_mint_refuses_inline_token_identity(capture_login):
+    # An inline-token cluster stores 'user@realm!tokenid' in config.user and the
+    # token SECRET in config.pass_ — pwd is truthy, but POSTing it to
+    # /access/ticket is a guaranteed 401 per console open (and bypasses the
+    # connect path's failed-login circuit breaker). The mint must bail without
+    # ever talking to PVE.
+    mgr = _manager(host='pve1.example', current_host=None, password='tokensecret')
+    mgr.config.user = 'automation@pve!provisioning'
+    assert mgr.mint_console_session() == (None, None)
+    assert 'url' not in capture_login

--- a/tests/test_console_session_mint.py
+++ b/tests/test_console_session_mint.py
@@ -1,0 +1,74 @@
+"""mint_console_session() must log in against the REGISTERED node.
+
+The stored @pam password is a local account on the node the cluster was
+registered with. `manager.host` follows the HA fallback, so a login there
+answers 401 and the console dies (#740, defect 2). The mint therefore has to
+target config.host regardless of which node the manager currently talks to.
+"""
+import io
+import json
+import logging
+import types
+import urllib.request
+
+import pytest
+
+from pegaprox.core.manager import PegaProxManager
+
+
+def _manager(*, host, current_host, password='s3cret'):
+    mgr = PegaProxManager.__new__(PegaProxManager)
+    mgr.config = types.SimpleNamespace(host=host, user='root@pam', pass_=password, api_port=8006)
+    mgr.current_host = current_host
+    mgr._ssl_verify = False
+    mgr.logger = logging.getLogger('test-mint')
+    return mgr
+
+
+class _Resp(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def capture_login(monkeypatch):
+    seen = {}
+
+    def fake_urlopen(req, context=None, timeout=None):
+        seen['url'] = req.full_url
+        body = json.dumps({'data': {'ticket': 'PVE:root@pam:TICKET', 'CSRFPreventionToken': 'CSRF'}})
+        return _Resp(body.encode())
+
+    monkeypatch.setattr(urllib.request, 'urlopen', fake_urlopen)
+    return seen
+
+
+def test_mint_targets_registered_host_not_ha_fallback(capture_login):
+    mgr = _manager(host='pve1.example', current_host='pve3.example')
+    ticket, csrf = mgr.mint_console_session()
+    assert ticket == 'PVE:root@pam:TICKET' and csrf == 'CSRF'
+    assert capture_login['url'].startswith('https://pve1.example:8006/')
+    assert 'pve3' not in capture_login['url']
+    # self.host would have been the fallback node — the exact bug
+    assert mgr.host == 'pve3.example'
+
+
+def test_mint_brackets_ipv6_registered_host(capture_login):
+    mgr = _manager(host='2001:db8::1', current_host='2001:db8::3')
+    mgr.mint_console_session()
+    assert capture_login['url'].startswith('https://[2001:db8::1]:8006/')
+
+
+def test_mint_returns_none_pair_for_token_registered_cluster(capture_login):
+    mgr = _manager(host='pve1.example', current_host=None, password='')
+    assert mgr.mint_console_session() == (None, None)
+    assert mgr.mint_console_auth_ticket() is None
+    assert 'url' not in capture_login
+
+
+def test_ticket_only_view_keeps_old_contract(capture_login):
+    mgr = _manager(host='pve1.example', current_host=None)
+    assert mgr.mint_console_auth_ticket() == 'PVE:root@pam:TICKET'


### PR DESCRIPTION
## **User description**
## What & why

The web console is unusable on a gevent deployment running Python ≥ 3.13. Three
independent defects sit on top of each other; each one alone still leaves the
console dead, which is why they come as one PR. All three were found by
bisecting on a live install, and every claim below is a measurement rather than
a reading of the code. The SSH console is unaffected throughout — it runs as a
subprocess, while the VNC path runs in-process.

### 1. The console socket never binds

`websockets.serve()` does not bind under gevent from Python 3.13 on. The
greenlet sits in `gevent/selectors.py` `select()` inside
`asyncio.base_events._run_once`, alive but never listening. Nothing raises, so
the log only reports a slow startup while the port stays closed.

| setup | result |
|---|---|
| `websockets.serve` + `monkey.patch_all()`, py3.12 | binds |
| `websockets.serve` + `monkey.patch_all()`, py3.13 | never binds |
| `websockets.serve` + `monkey.patch_all()`, py3.14 | never binds |
| `websockets.serve` without `monkey.patch_all()`, py3.14 | binds |
| `asyncio.start_server` + `monkey.patch_all()`, py3.12/3.13/3.14 | binds |

So it is neither Python 3.14 alone nor gevent-with-asyncio in general: only
`websockets.serve` under gevent, starting at 3.13 — inside the supported
3.10–3.13 window.

**Fix:** bind the listening socket with the original, unpatched `socket`
implementation and hand it to `websockets.serve(sock=...)`, bypassing the
emulation for the one call that cannot cope with it.

### 2. Authentication answers 401 on every node but one

With the bind fixed, the console still failed. `vnc_handler` performs its own
password login instead of reusing the manager's session, and aims it at
`manager.host` — which is `current_host or config.host` and therefore follows
the HA fallback. Since `@pam` is a local Unix account per node, that login hits
a node the stored cluster password does not belong to.

Measured against a three-node cluster: `/access/ticket` with the cluster
password returns OK on the registered node and **401 on both others**, while a
ticket issued by the registered node is accepted by all three — PVE tickets are
cluster-wide. `get_vnc_ticket` in `core/manager.py` is unaffected because it
goes through the manager's own session.

**Fix:** keep the audited design — a fresh session per console, never the
manager's own ticket (C-1) — but mint it against `config.host`, the registered
node. The mint moves into the manager as `mint_console_session()` (ticket +
CSRF token; `mint_console_auth_ticket()` keeps its ticket-only contract for the
WS-subprocess hand-off), so the termproxy path is fixed by the same change and
`vnc_handler` no longer carries a private copy of the login. The auth ticket
stays inside the process throughout; the browser only ever sees the VM-bound,
short-lived `vncticket` from `/vncproxy`. A token-registered cluster, which has
no password to mint with, now closes the socket with a clear reason instead of
burning the connect timeout.

### 3. `asyncio.to_thread` never delivers under gevent

With bind and auth fixed the console still timed out. The proxy pushes every
PVE-side socket call off the event loop with `asyncio.to_thread`. Under
`monkey.patch_all()` the executor's worker is a greenlet rather than an OS
thread, and the loop only observes the finished future once an unrelated timer
wakes it. One call doing 1 s of work, on Python 3.14:

| offload mechanism | resolves after |
|---|---|
| `asyncio.to_thread` | **8.01 s** — exactly the caller's timeout |
| `run_in_executor`, default and explicit pool | **8.01 s** |
| `threading.Thread` + `call_soon_threadsafe` | 1.00 s |
| `gevent.spawn` + `call_soon_threadsafe` | 1.00 s |

The wake-up path is intact; only the executor path is broken. The handshake
therefore burned `VNC_PVE_CONNECT_TIMEOUT` instead of connecting, and the
browser reported a timed-out console.

**Fix:** `gevent_to_thread()` in `utils/concurrent.py` keeps the contract of
`asyncio.to_thread`, and `install_gevent_to_thread()` routes the stock function
through it once — the same thing gevent does to `socket` and `threading`.

Two alternatives were rejected on evidence:

- *Patching only the connect call.* All nine call sites in `vnc_handler` are
  affected — connect, `recv`, `send`, `ping`, `send_binary`, `close` — so the
  session would have died after the first frame.
- *Replacing the offload with direct calls.* That blocks the event loop and
  kills the client→PVE direction and both keepalives. The offload exists for a
  reason; only its mechanism is broken.

Replacing the function once also avoids touching nine call sites in a handler
that is under active development.

Fixes #740

## Scope

- [x] This PR does **one thing**: it makes the VNC console work under gevent.
      The three commits are separable defects but not separately shippable — any
      one alone still leaves the console dead, so they are reviewed together and
      revert together. `install_gevent_to_thread()` is a no-op when gevent has
      not patched `threading`, so a plain WSGI deployment keeps the stock asyncio
      path; `to_thread` appears nowhere else in the codebase.

Commits, one per defect:

- `fix(vnc): make asyncio.to_thread deliver under gevent`
- `fix(vnc): bind the console socket with an unpatched socket module`
- `fix(vnc): mint the console session against the registered node`

## How it was tested

On a live install (Python 3.14, gevent, Proxmox VE 9):

- `to_thread` resolves in 1.00 s instead of 8.01 s, including through the module
  aliases the handler uses; exceptions propagate; the loop stays responsive
  (97 iterations during a 1 s blocking call); five parallel TLS handshakes
  complete in 0.05 s, so the concurrency the offload was built for is preserved.
- End-to-end against three registered clusters: RFB banner on each, about a
  second apiece, including on an HA-fallback node that previously answered 401.
- A full session completed VNC authentication, received
  `ServerInit 1280x800`, forwarded 4,096,095 bytes in 108 frames and stayed up
  for 60 s across both the WebSocket ping and the RFB keepalive.
- Service log reports `connect=10ms`.
- `python -m pytest`: **559 passed** — four new tests pin the mint's login
  target to the registered host (IPv4 and bracketed IPv6) and the `(None, None)`
  contract for token-registered clusters.

Re-verified after moving the mint into the manager, against two real clusters
(Proxmox VE 9) registered in a local Docker instance built from this branch:

| cluster | path | result |
|---|---|---|
| password-registered, 3 nodes | JS-issued vncproxy ticket passed through | `RFB 003.008` after 0.79 s |
| password-registered | handler issues its own vncproxy (mint + CSRF) | `RFB 003.008` after 1.08 s |
| password-registered | real noVNC UI in headless Chrome | `VNC: Connected!`, status "Connected", VM screen rendered (serial console banner visible) |
| token-registered (`user@pve!tokenid`) | handler must mint, cannot | closes `1011 "Console needs a password-registered cluster"` after 3.3 s — previously a 401 escaped the handler and the socket closed with no reason |

The HA-fallback defect itself was reproduced read-only against a second real
three-node cluster, with the manager put into the post-failover state
(`config.host` = node 1, `current_host` = node 3):

| measurement | result |
|---|---|
| login target of the OLD code (`manager.host`) | the fallback node |
| `/access/ticket` with the registered password on node 1 | **200** |
| same on nodes 2 and 3 | **401** — the bug, reproduced |
| `mint_console_session()` (targets `config.host`) in that state | ticket + CSRF OK |
| minted ticket used on the fallback node (`GET /version`) | **200** — tickets are cluster-wide |

PVE confirms the token limitation the manager documents: `/access/ticket` with
a token identity answers 401. (It does accept `Authorization: PVEAPIToken` on
`vncproxy` — a possible follow-up for token clusters, outside this PR.)

## Checklist

- [x] There's a linked issue and the approach was discussed.
- [x] The test suite passes locally; the auth defect has regression tests. The
      two gevent defects live in the gevent/asyncio interplay of a running
      process, which the in-process suite cannot exercise — verification there is
      the live measurement above.
- [x] It's scoped to the title and doesn't touch unrelated files.
- [x] If I used an AI assistant, I have read, understood and tested every line myself.


___

## **CodeAnt-AI Description**
Restore VNC console connectivity under gevent

### What Changed
- VNC consoles now bind and accept browser connections on gevent deployments running Python 3.13 and newer
- Console connections no longer wait for the full timeout when making PVE socket calls under gevent
- Fresh console sessions log in against the registered PVE node, avoiding authentication failures after HA fallback
- Token-only clusters receive a clear console error instead of an unexplained connection timeout
- Added coverage for registered-node login, IPv6 addresses, missing passwords, and ticket compatibility

### Impact
`✅ Fewer VNC connection timeouts`
`✅ Working VNC consoles on Python 3.13+ with gevent`
`✅ Clearer errors for token-only clusters`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VNC console connectivity when gevent is enabled.
  * Fixed console session creation for high-availability and IPv6 hosts.
  * Prevented connection attempts when password-based authentication is unavailable.
  * Improved asynchronous task handling for reliable console access.

* **Tests**
  * Added coverage for console session creation, host selection, IPv6 URLs, and token-based authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->