### PR TITLE
fix(xcmigrate): send PVE an UPPERCASE cert fingerprint (#733)

### DIFF
--- a/pegaprox/api/vms.py
+++ b/pegaprox/api/vms.py
@@ -10596,13 +10596,22 @@ def cross_cluster_migrate_api():
             f"fingerprint={fp_result['fingerprint']}"
         )
         
-        logging.info(f"Starting remote migration of {vm_type}/{vmid} from {source_cluster_id} to {target_cluster_id}...")
         # MK Aug 2026 (#733) — log the host + fingerprint we hand to PVE. remote_migrate on a
         # target added without SSL trust rejects with a bare {"data":null}/500 and swallows the
         # real reason, so this is often the only way to tell whether the fp we computed matches
         # the one the source node actually sees. The fingerprint is public cert data — the token
         # secret is NOT logged (the full target-endpoint stays redacted in remote_migrate_vm).
-        logging.info(f"Target host: {fp_result['host']}, fingerprint: {fp_result['fingerprint']}, Token user: {target_token['token_id'].split('!')[0]}, Online: {online}")
+        #
+        # (#733 follow-up) Both lines go to the SOURCE cluster logger, not the root logger.
+        # As root-logger INFO they reached nobody on a stock container: app.py's basicConfig()
+        # leaves root at WARNING unless --debug or PEGAPROX_LOG_LEVEL is set (the Dockerfile
+        # ENTRYPOINT passes no args), and it attaches no FileHandler, so even at INFO they would
+        # only hit stderr — never logs/<cluster>.log, whose per-cluster loggers set
+        # propagate=False. The reporter tailing logs/ correctly saw nothing. The cluster logger
+        # writes the file handler (DEBUG by default) right next to the "Remote migrating" /
+        # "Migration data" lines people actually paste into issues.
+        source_manager.logger.info(f"Starting remote migration of {vm_type}/{vmid} from {source_cluster_id} to {target_cluster_id}...")
+        source_manager.logger.info(f"Target host: {fp_result['host']}, fingerprint: {fp_result['fingerprint']}, Token user: {target_token['token_id'].split('!')[0]}, Online: {online}")
         
         # Step 4: Perform the migration
         result = source_manager.remote_migrate_vm(

--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -9551,8 +9551,18 @@ echo "AGENT_INSTALLED_OK"
                 with context.wrap_socket(sock, server_hostname=self.config.host) as ssock:
                     cert_der = ssock.getpeercert(binary_form=True)
                     fingerprint = hashlib.sha256(cert_der).hexdigest()
-                    # Format as colon-separated
-                    fingerprint_formatted = ':'.join(fingerprint[i:i+2] for i in range(0, len(fingerprint), 2))
+                    # Format as colon-separated UPPERCASE hex.
+                    #
+                    # (#733) This is not cosmetic. PVE looks the fingerprint we hand it up as a
+                    # raw hash key with no case normalisation — PVE::APIClient::LWP does
+                    # `$fingerprint->{cache}->{$fp}`, and the $fp it compares against comes from
+                    # Net::SSLeay::X509_get_fingerprint, which formats with "%02X:" (uppercase).
+                    # A lowercase fingerprint parses fine (the pve-fingerprint-sha256 format
+                    # accepts [A-Fa-f0-9]) but never matches, so remote_migrate aborts on the
+                    # cert check and PVE returns a bare {"data":null}/500 with the real reason
+                    # swallowed. Every other fingerprint path here already uppercases —
+                    # api/vms.py:421, :470, :2748 — this one was the outlier.
+                    fingerprint_formatted = ':'.join(fingerprint[i:i+2].upper() for i in range(0, len(fingerprint), 2))
             
             return {
                 'success': True, 

--- a/tests/test_xcmigrate_fingerprint_case_733.py
+++ b/tests/test_xcmigrate_fingerprint_case_733.py
@@ -1,0 +1,93 @@
+# #733 — cross-cluster migrate handed PVE a LOWERCASE cert fingerprint, and PVE compares the
+# fingerprint it is given as a raw hash key: PVE::APIClient::LWP does `$fingerprint->{cache}->{$fp}`
+# with no uc()/lc(), and the $fp it builds comes from Net::SSLeay::X509_get_fingerprint, which
+# formats with "%02X:". So a lowercase fingerprint parses (pve-fingerprint-sha256 accepts
+# [A-Fa-f0-9]) but never matches — remote_migrate aborts on the cert check and PVE answers with a
+# bare {"data":null}/500, the real reason swallowed. Nothing in the log says "fingerprint".
+#
+# The invariant: whatever we put in target-endpoint's fingerprint= must be PVE's own rendering,
+# i.e. colon-separated UPPERCASE hex.
+
+import hashlib
+import socket
+import ssl
+import types
+
+from pegaprox.core.manager import PegaProxManager
+
+
+# A stand-in DER blob — get_cluster_fingerprint only ever hashes these bytes.
+CERT_DER = b'\x30\x82\x01\x0a\x02\x82\x01\x01\x00#733 not a real certificate'
+EXPECTED_HEX = hashlib.sha256(CERT_DER).hexdigest()
+EXPECTED_FP = ':'.join(EXPECTED_HEX[i:i + 2].upper() for i in range(0, len(EXPECTED_HEX), 2))
+
+
+class _FakeTLSSocket:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def getpeercert(self, binary_form=False):
+        return CERT_DER
+
+
+class _FakeContext:
+    check_hostname = True
+    verify_mode = None
+
+    def wrap_socket(self, sock, server_hostname=None):
+        return _FakeTLSSocket()
+
+
+# RFC 5737 TEST-NET-1, reserved for documentation and guaranteed never to be a real host.
+# Nothing here is dialed — the socket/ssl calls are stubbed below — but if that stubbing ever
+# silently stops applying, a reserved address fails closed instead of connecting to a stranger.
+DOC_HOST = '192.0.2.14'
+DOC_HOST_ALT = '192.0.2.9'
+
+
+def _manager(monkeypatch, host=DOC_HOST):
+    """A stub self for the unbound method — it touches only these three attributes."""
+    monkeypatch.setattr(socket, 'create_connection', lambda *a, **kw: _FakeTLSSocket())
+    monkeypatch.setattr(ssl, 'create_default_context', lambda *a, **kw: _FakeContext())
+    return types.SimpleNamespace(
+        is_connected=True,
+        config=types.SimpleNamespace(host=host),
+        logger=types.SimpleNamespace(error=lambda *a, **kw: None),
+    )
+
+
+def test_fingerprint_is_uppercase_colon_hex(monkeypatch):
+    result = PegaProxManager.get_cluster_fingerprint(_manager(monkeypatch))
+
+    assert result['success'] is True
+    assert result['fingerprint'] == EXPECTED_FP
+
+
+def test_fingerprint_is_not_lowercase(monkeypatch):
+    # The exact #733 regression: same digest, wrong case, PVE's lookup misses.
+    lowercase = ':'.join(EXPECTED_HEX[i:i + 2] for i in range(0, len(EXPECTED_HEX), 2))
+    result = PegaProxManager.get_cluster_fingerprint(_manager(monkeypatch))
+
+    assert result['fingerprint'] != lowercase
+    assert result['fingerprint'].upper() == result['fingerprint']
+
+
+def test_fingerprint_shape_matches_pve_format(monkeypatch):
+    # pve-fingerprint-sha256: 32 colon-separated hex octets.
+    fp = PegaProxManager.get_cluster_fingerprint(_manager(monkeypatch))['fingerprint']
+    octets = fp.split(':')
+
+    assert len(octets) == 32
+    assert all(len(o) == 2 and set(o) <= set('0123456789ABCDEF') for o in octets)
+
+
+def test_host_is_reported_alongside(monkeypatch):
+    # The endpoint pairs host= with fingerprint= — the source node dials this host, so a
+    # migration diagnosis needs both together (see the diag line in api/vms.py).
+    result = PegaProxManager.get_cluster_fingerprint(_manager(monkeypatch, host=DOC_HOST_ALT))
+
+    assert result['host'] == DOC_HOST_ALT
+    assert result['port'] == 8006


### PR DESCRIPTION
## **User description**
## What & why

Cross-cluster migrate fails with a bare `{"data":null}` / HTTP 500 roughly 50 ms after it starts,
with nothing in any log naming a fingerprint.

`get_cluster_fingerprint()` (`core/manager.py`) rendered the SHA-256 as **lowercase** colon-hex.
PVE compares the fingerprint it is handed as a **raw hash key, with no case normalisation**:

* `PVE::APIClient::LWP` — `my $valid = $fingerprint->{cache}->{$fp};`, no `uc()`/`lc()` anywhere,
  and `cache => $param{cached_fingerprints} || {}` stores what it was given verbatim.
* the `$fp` it compares against comes from `Net::SSLeay::X509_get_fingerprint`, which builds the
  string with `sprintf(&text[strlen(text)], "%02X:", digest[k])` — **uppercase** (`SSLeay.xs`).

So a lowercase fingerprint passes format validation (`pve-fingerprint-sha256` accepts `[A-Fa-f0-9]`)
and then silently never matches. `remote_migrate` aborts on the certificate check before it does any
work, and PVE returns the bare `{"data":null}`/500 with the real reason swallowed — exactly the
symptom in the issue, including the ~50 ms failure and the empty `pvedaemon` journal.

This matches the reporter's own isolation in #733: the identical migration run by hand as
`pvesh create … remote_migrate --target-endpoint '…,fingerprint=<the one PVE itself prints>'`
completes normally.

Every other fingerprint path in the codebase already uppercases — `api/vms.py:421`, `:470`, `:2748`
(and `api/pbs.py` normalises operator input with `.upper()`). `get_cluster_fingerprint()` was the
outlier, and it feeds all four cross-cluster paths: `api/vms.py` cross-cluster migrate, the
replication endpoint at `api/vms.py:7150`, `background/site_recovery.py` and
`background/cross_cluster_lb.py`. I checked every consumer — none compares the value against a
stored fingerprint, so uppercasing is safe.

Refs #733

**Second hunk, same issue:** the two remote-migration diagnostic lines (including the `Target host:
…, fingerprint: …` line added in 3ab32d7 to debug this) now log to the **source cluster logger**
instead of the root logger. As root-logger `INFO` they could not reach anyone on a stock container:
`app.py`'s `basicConfig()` leaves root at `WARNING` unless `--debug` or `PEGAPROX_LOG_LEVEL` is set
(the Dockerfile `ENTRYPOINT` passes no args), and it attaches no `FileHandler` — while
`logs/<cluster>.log` is written by the per-cluster loggers, which set `propagate = False`. The line
was therefore invisible both in `logs/` and in `docker logs`, which is why #733 stalled. On the
cluster logger it lands next to the `Remote migrating` / `Migration data` lines people actually
paste into issues. Happy to split this into its own PR if you'd rather keep them separate.

## Scope

- [x] This PR does **one thing**. Unrelated changes (a security fix + a feature + a refactor) belong
      in separate PRs so each can be reviewed and reverted on its own.

## How it was tested

* `tests/test_xcmigrate_fingerprint_case_733.py` (new) — stubs the TLS handshake so no live cluster
  is needed, and asserts the fingerprint is colon-separated uppercase, is *not* the lowercase
  rendering, and matches the `pve-fingerprint-sha256` shape (32 hex octets).
  Verified it is not vacuous: with the `manager.py` change reverted, 3 of its 4 tests **fail**;
  with the fix applied all 4 pass.
* Full suite on this branch: **667 passed** (`python -m pytest`, from the repo root).
* The upstream behaviour above was read from the actual sources (`pve-apiclient`'s
  `PVE/APIClient/LWP.pm` and Net::SSLeay's `SSLeay.xs`), not inferred from the symptom.

Not yet re-run as a live cross-cluster migration on my PVE 8.3.3 → 9.2.10 pair — I'll confirm on the
next Testing image that carries this and report back in #733.

## Checklist

- [x] There's a linked issue and the approach was discussed — or this is a small, obvious fix.
- [x] The test suite passes locally, and I added/updated tests for this change.
- [x] It's scoped to the title and doesn't touch unrelated files.
- [x] If I used an AI assistant, **I have read, understood and tested every line myself** (this is
      not unreviewed generated output), **and I've named the assistant/model below** — we record it
      for licensing & compliance review.
      AI tool / model used: `Claude Opus 5 (Claude Code)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix cross-cluster migrations that fail because of certificate fingerprint casing

### What Changed
- Sends Proxmox certificate fingerprints in the uppercase format required for cross-cluster migration validation.
- Writes migration host and fingerprint diagnostics to the source cluster log, where operators can find them during failures.
- Adds regression coverage for uppercase formatting, Proxmox fingerprint shape, and reported connection details.

### Impact
`✅ Fewer cross-cluster migration failures`
`✅ Clearer certificate-mismatch diagnostics`
`✅ Consistent Proxmox fingerprint matching`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Corrected certificate fingerprint formatting to use uppercase hexadecimal values for improved PVE compatibility.
* Improved visibility of remote migration details in the source cluster’s log file.

## Tests

* Added coverage for fingerprint formatting and connection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->