### PR TITLE
fix(ssh): write a key OpenSSH can actually load (#717)

### DIFF
--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -179,6 +179,25 @@ def _wrap_with_sudo(cmd):
     return f"echo {enc} | base64 -d | sudo -n bash"
 
 
+def _normalise_private_key(key):
+    """Make a configured private key safe to write to a file for `ssh -i`.
+
+    #717 — OpenSSH refuses a key file that does not end in a newline, and one with CRLF
+    line endings; both fail as `Load key "...": invalid format`. ssh then has no identity
+    to offer, the node answers `Permission denied (publickey).`, and the operator is told
+    to add an SSH key they already added — the key never left the container. The paste
+    path does not normalise anything (the textarea sends `e.target.value` verbatim and the
+    DB stores it encrypted as-is), so normalise here, once, for every SSH path.
+
+    Returns '' when there is no usable key, so callers can bail instead of writing an
+    empty file and getting the same opaque `invalid format` back.
+    """
+    if not key or not key.strip():
+        return ''
+    data = key.replace('\r\n', '\n').replace('\r', '\n').strip()
+    return data + '\n'
+
+
 def _ssh_stderr_excerpt(stderr, max_chars=240):
     """Last meaningful line of SSH stderr, capped.
 
@@ -194,6 +213,13 @@ def _ssh_stderr_excerpt(stderr, max_chars=240):
     lines = [ln.strip() for ln in stderr.splitlines() if ln.strip()]
     if not lines:
         return 'no error output'
+    # #717 — but OpenSSH prints `Load key "...": invalid format` BEFORE the generic
+    # `Permission denied (publickey).`, so last-line-only threw away the one line that
+    # says our own key never loaded, and what remained read as a node-side rejection.
+    # Keep both when the key itself failed to load.
+    load_err = next((ln for ln in lines if ln.lower().startswith('load key')), None)
+    if load_err and load_err != lines[-1]:
+        return f"{load_err} | {lines[-1]}"[:max_chars]
     return lines[-1][:max_chars]
 
 
@@ -210,6 +236,14 @@ def _ssh_auth_hint(stderr):
     if not stderr:
         return None
     low = stderr.lower()
+    # #717 — check this BEFORE 'permission denied': when our key fails to load, ssh emits
+    # BOTH lines, and the publickey branch below would otherwise tell an operator who has
+    # already configured a key to go add one.
+    if 'load key' in low and ('invalid format' in low or 'error in libcrypto' in low
+                              or 'bad permissions' in low):
+        return ("the configured SSH private key could not be loaded (invalid format) — "
+                "re-paste it in the cluster's SSH key field: it must be the complete "
+                "PEM/OpenSSH block with LF line endings, ending in a newline")
     if 'host key verification failed' in low:
         return ("the node's SSH host key changed — clear the pinned entry to re-pin it "
                 "(cluster edit reconnects and re-learns it)")
@@ -6732,8 +6766,16 @@ echo "AGENT_INSTALLED_OK"
         try:
             import tempfile
 
+            # #717 — write a key OpenSSH can actually load (see _normalise_private_key).
+            # The sibling _ssh_run_command_with_key has always done this; this path did not,
+            # so a stored key missing its trailing newline failed here and nowhere else.
+            key_data = _normalise_private_key(key)
+            if not key_data:
+                self.logger.debug(f"[SSH] No usable private key configured for {host}")
+                return None
+
             with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.key') as f:
-                f.write(key)
+                f.write(key_data)
                 key_file = f.name
             os.chmod(key_file, 0o600)
             
@@ -7648,7 +7690,8 @@ echo "AGENT_INSTALLED_OK"
         if host and host.startswith('[') and host.endswith(']'):
             host = host[1:-1]
 
-        if not key_content or not key_content.strip():
+        key_content = _normalise_private_key(key_content)
+        if not key_content:
             return False
         
         key_fd = None
@@ -7660,11 +7703,8 @@ echo "AGENT_INSTALLED_OK"
             os.chmod(key_path, 0o600)
             
             with os.fdopen(key_fd, 'w') as f:
-                # Ensure key has proper newlines
-                key_data = key_content.strip()
-                if not key_data.endswith('\n'):
-                    key_data += '\n'
-                f.write(key_data)
+                # normalised above by _normalise_private_key (#717)
+                f.write(key_content)
             key_fd = None  # fd is now closed
             
             self.logger.info(f"[HA] Trying SSH with configured key...")

--- a/tests/test_ssh_key_normalisation_717.py
+++ b/tests/test_ssh_key_normalisation_717.py
@@ -1,0 +1,106 @@
+# #717 — a configured SSH key that PegaProx could not load looked exactly like a node
+# refusing it. OpenSSH will not read a private key file that lacks a trailing newline, or
+# one with CRLF endings: it prints `Load key "...": invalid format`, then has no identity
+# to offer, so the node answers `Permission denied (publickey).` and PegaProx told the
+# operator to add an SSH key they had already added. Reporter's sshd journal confirmed it:
+# `Connection closed by authenticating user root ... [preauth]` with no `Failed publickey`
+# line at all — the key never reached the wire.
+#
+# Invariants: (1) whatever we write for `ssh -i` is loadable, (2) an absent key is refused
+# up front rather than written as an empty file, (3) the load failure survives into the log
+# instead of being trimmed away, and (4) the hint names the key, not the node.
+
+from pegaprox.core.manager import (
+    _normalise_private_key,
+    _ssh_stderr_excerpt,
+    _ssh_auth_hint,
+)
+
+
+BODY = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA\n-----END OPENSSH PRIVATE KEY-----"
+
+
+# ---- (1) the file we write is loadable ----
+
+def test_missing_trailing_newline_is_added():
+    # the reporter's case: pasted from an editor selection, no final newline
+    assert _normalise_private_key(BODY).endswith('-----END OPENSSH PRIVATE KEY-----\n')
+
+
+def test_crlf_is_converted_to_lf():
+    out = _normalise_private_key(BODY.replace('\n', '\r\n'))
+
+    assert '\r' not in out
+    assert out.endswith('\n')
+
+
+def test_bare_cr_is_converted_to_lf():
+    out = _normalise_private_key(BODY.replace('\n', '\r'))
+
+    assert '\r' not in out
+    assert out == BODY + '\n'
+
+
+def test_already_correct_key_is_unchanged():
+    good = BODY + '\n'
+
+    assert _normalise_private_key(good) == good
+
+
+def test_surrounding_whitespace_does_not_survive():
+    assert _normalise_private_key('\n\n  ' + BODY + '  \n\n') == BODY + '\n'
+
+
+# ---- (2) an absent key is refused, not written as an empty file ----
+
+def test_empty_and_blank_keys_return_empty():
+    for missing in ('', '   ', '\n', '\r\n', None):
+        assert _normalise_private_key(missing) == ''
+
+
+# ---- (3) the load failure survives into the log ----
+
+LOAD_FAIL_STDERR = (
+    'Load key "/tmp/tmp1234.key": invalid format\n'
+    'root@192.0.2.18: Permission denied (publickey).\n'
+)
+
+
+def test_excerpt_keeps_the_load_failure():
+    out = _ssh_stderr_excerpt(LOAD_FAIL_STDERR)
+
+    # both halves matter: what failed, and what the node then said
+    assert 'invalid format' in out
+    assert 'Permission denied' in out
+
+
+def test_excerpt_still_returns_last_line_when_nothing_failed_to_load():
+    stderr = '***  banner  ***\nroot@192.0.2.18: Permission denied (publickey).\n'
+
+    assert _ssh_stderr_excerpt(stderr) == 'root@192.0.2.18: Permission denied (publickey).'
+
+
+def test_excerpt_respects_the_cap():
+    assert len(_ssh_stderr_excerpt(LOAD_FAIL_STDERR, max_chars=20)) == 20
+
+
+# ---- (4) the hint names the key, not the node ----
+
+def test_hint_for_unloadable_key_points_at_the_key():
+    hint = _ssh_auth_hint(LOAD_FAIL_STDERR)
+
+    assert 'could not be loaded' in hint
+    # the #717 misfire: telling someone who HAS configured a key to add one
+    assert 'add an authorized SSH key' not in hint
+
+
+def test_hint_for_a_genuine_key_only_node_is_unchanged():
+    hint = _ssh_auth_hint('root@192.0.2.18: Permission denied (publickey).')
+
+    assert 'add an authorized SSH key' in hint
+
+
+def test_hint_for_changed_host_key_is_unchanged():
+    hint = _ssh_auth_hint('Host key verification failed.')
+
+    assert 're-pin' in hint or 'host key changed' in hint


### PR DESCRIPTION
## **User description**
## What & why

A configured SSH key that PegaProx could not load was indistinguishable from a node refusing it.

OpenSSH will not read a private key file that lacks a trailing newline, or one with CRLF line
endings. It prints `Load key "...": invalid format`, then has no identity left to offer, so the
node answers `Permission denied (publickey).` Three things then conspired to point the operator at
the node instead of at the key:

* `_ssh_run_command_with_key_output` wrote the stored key **verbatim**. Its sibling
  `_ssh_run_command_with_key` has always normalised the trailing newline, so a key missing one
  failed on this path and nowhere else. Nothing upstream normalises it either — the textarea sends
  `e.target.value` as-is and the DB stores it encrypted verbatim. Both paths now share
  `_normalise_private_key`, and an absent key is refused up front instead of being written as an
  empty file and coming back as the same opaque `invalid format`.
* `_ssh_stderr_excerpt` keeps only the last non-empty stderr line (to skip login banners), and
  OpenSSH prints the load failure *before* the permission-denied line — so the one line naming the
  real fault was the one line thrown away. It now keeps both when a key failed to load.
* `_ssh_auth_hint` saw `(publickey)` in what was left and told the operator to add an authorized SSH
  key for a cluster that already had one. It now recognises a key that did not load, checked before
  the publickey branch since ssh emits both lines.

Fixes #717

## Scope

- [x] This PR does **one thing**. Unrelated changes (a security fix + a feature + a refactor) belong
      in separate PRs so each can be reviewed and reverted on its own.

## How it was tested

Against my own 6-node PVE cluster (Janus), root SSH with `PermitRootLogin without-password`, key
configured in the cluster's SSH key field.

Before, on every node, `sshd` logged only:

```
Connection closed by authenticating user root 192.168.100.24 port 32770 [preauth]
```

No `Failed publickey` line, no fingerprint — the key never reached the wire, while PegaProx logged
`Permission denied (publickey).` and told me to add a key I had already added. After:

```
Accepted publickey for root from 192.168.100.24 port 56598 ssh2: ED25519 SHA256:ZjIGql0...
pam_unix(sshd:session): session opened for user root(uid=0)
```

The compliance scan reaches all 6 nodes and returns real results now.

Also ran both log helpers against the exact stderr from the failing case:

```
before  excerpt: root@...: Permission denied (publickey).
        hint   : node accepts SSH key auth only ... add an authorized SSH key
after   excerpt: Load key "...": invalid format | root@...: Permission denied (publickey).
        hint   : the configured SSH private key could not be loaded (invalid format) ...
```

`tests/test_ssh_key_normalisation_717.py` — 12 cases covering the normaliser, the excerpt and both
hint branches. Full suite: **679 passed**.

## Checklist

- [x] There's a linked issue and the approach was discussed — or this is a small, obvious fix.
- [x] The test suite passes locally, and I added/updated tests for this change.
- [x] It's scoped to the title and doesn't touch unrelated files.
- [ ] If I used an AI assistant, **I have read, understood and tested every line myself** (this is
      not unreviewed generated output), **and I've named the assistant/model below** — we record it
      for licensing & compliance review.
      AI tool / model used: `Claude Opus 5 (Claude Code)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make configured SSH keys loadable and SSH failures easier to diagnose

### What Changed
- Normalizes configured private keys before SSH uses them, including line endings, surrounding whitespace, and a missing final newline.
- Refuses empty or blank keys before attempting a connection.
- Preserves key-loading errors alongside permission errors so logs identify when the configured key could not be loaded.
- Shows instructions to re-paste an invalid key instead of incorrectly telling users to add an authorized key to the node.
- Adds coverage for key normalization, empty keys, error reporting, and unchanged SSH failure hints.

### Impact
`✅ Fewer SSH failures caused by pasted key formatting`
`✅ Clearer invalid-key troubleshooting`
`✅ No empty-key connection attempts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH private-key handling by normalizing line endings, removing excess whitespace, and ensuring required trailing newlines.
  * Added clearer error messages when an SSH key cannot be loaded, while preserving useful diagnostic details.
  * Prevented connection attempts when no usable private key is configured.
  * Applied consistent key handling across standard SSH and high-availability connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->