### PR TITLE
fix(app): fix shutdown python errors

### DIFF
--- a/pegaprox/api/vms.py
+++ b/pegaprox/api/vms.py
@@ -9921,9 +9921,11 @@ if __name__ == '__main__':
         output_thread.start()
         
         print(f"SSH WebSocket server subprocess started (PID: {proc.pid})", flush=True)
+        return proc
 
     except Exception as e:
         print(f"Failed to start SSH WebSocket server: {e}", flush=True)
+        return None
 
 
 # Terminal/Shell WebSocket proxy (legacy - flask-sock version, kept for non-gevent setups)

--- a/pegaprox/app.py
+++ b/pegaprox/app.py
@@ -1520,14 +1520,18 @@ def _start_gevent_server(app, bind_host, port, ssl_context, domain, workers, htt
     # Custom error handler to suppress SSL errors (from bots/scanners/disconnects)
     class QuietWSGIServer(WSGIServer):
         def wrap_socket_and_handle(self, client_socket, address):
-            """Override to catch SSL errors during handshake"""
+            """Override to catch SSL errors and shutdown GreenletExit during handshake"""
             try:
                 return super().wrap_socket_and_handle(client_socket, address)
-            except Exception as e:
-                if 'ssl' in str(type(e).__name__).lower() or 'ssl' in str(e).lower():
-                    pass
-                else:
+            except BaseException as e:
+                # GreenletExit (raised by gevent when a connection greenlet is
+                # cancelled during shutdown) is a BaseException, not an Exception,
+                # so catch it explicitly and suppress it - it's expected at exit.
+                if isinstance(e, Exception):
+                    if 'ssl' in str(type(e).__name__).lower() or 'ssl' in str(e).lower():
+                        return
                     raise
+                return
 
         def handle_error(self, *args):
             """Suppress SSL errors - they're normal with self-signed certs"""
@@ -1721,8 +1725,13 @@ def _start_gevent_server(app, bind_host, port, ssl_context, domain, workers, htt
     # Handle graceful shutdown
     def signal_handler(signum, frame):
         print("\nShutting down gracefully...")
-        http_server.stop()
-        sys.exit(0)
+        # gevent runs signal handlers inside the hub greenlet, where blocking
+        # calls (like http_server.stop() -> pool.join()) are illegal and raise
+        # BlockingSwitchOutError. Defer the shutdown to a dedicated greenlet so
+        # the hub is never blocked; serve_forever() returns once stop() sets the
+        # stop event.
+        from gevent import spawn
+        spawn(http_server.stop)
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)

--- a/pegaprox/app.py
+++ b/pegaprox/app.py
@@ -16,6 +16,7 @@ import gc
 import multiprocessing
 import ssl
 import socket
+from greenlet import GreenletExit
 
 from flask import Flask, jsonify, request
 from flask_cors import CORS
@@ -1220,7 +1221,13 @@ def main(debug_mode=False):
 
 
 def _start_console_servers(bind_host, port, ssl_context):
-    """Start VNC and SSH WebSocket servers on port+1 and port+2."""
+    """Start VNC and SSH WebSocket servers on port+1 and port+2.
+
+    Returns the SSH WebSocket subprocess handle (a Popen) so the caller can
+    terminate it on shutdown. The VNC server runs as a daemon thread and needs
+    no handle; the SSH server is a long-running asyncio subprocess that would
+    otherwise outlive the parent.
+    """
     vnc_ws_port = port + 1
     ssh_ws_port = port + 2
 
@@ -1228,25 +1235,28 @@ def _start_console_servers(bind_host, port, ssl_context):
         from pegaprox.api.vms import start_vnc_websocket_server, start_ssh_websocket_server
     except ImportError as e:
         print(f"WARNING: Console WebSocket servers not available: {e}")
-        return
+        return None
 
     # NS Feb 2026 - asyncio/websockets creates IPv6-only socket for '::' (#95)
     # Use '' so asyncio binds to ALL interfaces (creates both IPv4 + IPv6 listeners)
     console_host = '' if bind_host == '::' else bind_host
 
     # MK Feb 2026 - start each server independently so one failure doesn't block the other
+    ssh_proc = None
     for name, start_fn, ws_port in [
         ("VNC", start_vnc_websocket_server, vnc_ws_port),
         ("SSH", start_ssh_websocket_server, ssh_ws_port),
     ]:
         try:
-            if ssl_context:
-                start_fn(ws_port, ssl_cert=ssl_context[0], ssl_key=ssl_context[1], host=console_host)
-            else:
-                start_fn(ws_port, host=console_host)
+            result = start_fn(ws_port, ssl_cert=ssl_context[0], ssl_key=ssl_context[1], host=console_host) if ssl_context else start_fn(ws_port, host=console_host)
+            # Only the SSH server returns a live subprocess handle; capture it.
+            if name == "SSH" and result is not None:
+                ssh_proc = result
         except Exception as e:
             print(f"ERROR: {name} WebSocket server (port {ws_port}) failed to start: {e}")
             logging.error(f"{name} WebSocket server startup failed: {e}", exc_info=True)
+
+    return ssh_proc
 
 
 def _test_ipv6_available():
@@ -1523,14 +1533,15 @@ def _start_gevent_server(app, bind_host, port, ssl_context, domain, workers, htt
             """Override to catch SSL errors and shutdown GreenletExit during handshake"""
             try:
                 return super().wrap_socket_and_handle(client_socket, address)
-            except BaseException as e:
-                # GreenletExit (raised by gevent when a connection greenlet is
-                # cancelled during shutdown) is a BaseException, not an Exception,
-                # so catch it explicitly and suppress it - it's expected at exit.
-                if isinstance(e, Exception):
-                    if 'ssl' in str(type(e).__name__).lower() or 'ssl' in str(e).lower():
-                        return
-                    raise
+            except Exception as e:
+                if 'ssl' in str(type(e).__name__).lower() or 'ssl' in str(e).lower():
+                    return
+                raise
+            except GreenletExit:
+                # Raised by gevent when a connection greenlet is cancelled
+                # during shutdown; expected at exit and should be suppressed.
+                # KeyboardInterrupt, SystemExit and GeneratorExit are separate
+                # BaseException subclasses intentionally not caught here.
                 return
 
         def handle_error(self, *args):
@@ -1719,19 +1730,31 @@ def _start_gevent_server(app, bind_host, port, ssl_context, domain, workers, htt
         print("WARNING: Running without HTTPS - noVNC console may not work!", flush=True)
         http_server = QuietWSGIServer(_create_listener(bind_host, port), app, **server_kwargs)
 
-    # Start VNC/SSH WebSocket servers
-    _start_console_servers(bind_host, port, ssl_context)
+    # Start VNC/SSH WebSocket servers. Returns the SSH subprocess handle so we
+    # can terminate it on shutdown; the VNC server is a daemon thread and needs
+    # no handle.
+    ssh_ws_proc = _start_console_servers(bind_host, port, ssl_context)
 
     # Handle graceful shutdown
     def signal_handler(signum, frame):
         print("\nShutting down gracefully...")
+        # terminate() sends SIGTERM and returns immediately, so it is safe to
+        # call from the hub's signal callback. The standalone SSH WebSocket
+        # server runs its own asyncio loop awaiting Future() forever, so
+        # nothing else stops it.
+        if ssh_ws_proc is not None and ssh_ws_proc.poll() is None:
+            try:
+                ssh_ws_proc.terminate()
+            except Exception:
+                pass
         # gevent runs signal handlers inside the hub greenlet, where blocking
-        # calls (like http_server.stop() -> pool.join()) are illegal and raise
-        # BlockingSwitchOutError. Defer the shutdown to a dedicated greenlet so
-        # the hub is never blocked; serve_forever() returns once stop() sets the
-        # stop event.
+        # calls (http_server.stop() -> pool.join()) are illegal and raise
+        # BlockingSwitchOutError. Defer the shutdown to a dedicated greenlet and
+        # bound the join with a timeout so long-lived SSE/WebSocket connections
+        # can't keep shutdown waiting forever. serve_forever() returns once
+        # stop() sets the stop event.
         from gevent import spawn
-        spawn(http_server.stop)
+        spawn(lambda: http_server.stop(timeout=10))
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)


### PR DESCRIPTION
## **User description**
<!--
Thanks for contributing to PegaProx! We're a small volunteer team — a focused, tested PR against a
discussed issue gets merged fast. Please fill this in; PRs that leave it blank are hard to review.
-->

## What & why

<!-- What does this change, and what problem does it solve? -->
fixes several shutdown errors when using CTRL+C at command line (debug mode)
```
Shutting down gracefully...
Traceback (most recent call last):
  File "/opt/PegaProx/pegaprox/app.py", line 1724, in signal_handler
    http_server.stop()
    ~~~~~~~~~~~~~~~~^^
  File "/opt/PegaProx/venv/lib/python3.13/site-packages/gevent/baseserver.py", line 393, in stop
    self.pool.join(timeout=timeout)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/PegaProx/venv/lib/python3.13/site-packages/gevent/pool.py", line 430, in join
    result = self._empty_event.wait(timeout=timeout)
  File "src/gevent/event.py", line 165, in gevent._gevent_cevent.Event.wait
  File "src/gevent/_abstract_linkable.py", line 529, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait
  File "src/gevent/_abstract_linkable.py", line 495, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 498, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 450, in gevent._gevent_c_abstract_linkable.AbstractLinkable._AbstractLinkable__wait_to_be_notified
  File "src/gevent/_abstract_linkable.py", line 459, in gevent._gevent_c_abstract_linkable.AbstractLinkable._switch_to_hub
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 64, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 67, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch_out
  File "src/gevent/_greenlet_primitives.py", line 68, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch_out
gevent.exceptions.BlockingSwitchOutError: Impossible to call blocking function in the event loop callback
2026-09-03T18:02:49Z
```
```
Exception has occurred: GreenletExit
exception: no description
  File "/opt/PegaProx/pegaprox/app.py", line 1525, in wrap_socket_and_handle
    return super().wrap_socket_and_handle(client_socket, address)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
greenlet.GreenletExit: 
```
```
Exception has occurred: BlockingSwitchOutError
Impossible to call blocking function in the event loop callback
  File "/opt/PegaProx/pegaprox/app.py", line 1724, in signal_handler
    http_server.stop()
    ~~~~~~~~~~~~~~~~^^
  File "/opt/PegaProx/pegaprox/app.py", line 1731, in _start_gevent_server
    http_server.serve_forever()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/opt/PegaProx/pegaprox/app.py", line 1200, in main
    _start_gevent_server(app, bind_host, port, ssl_context, domain, workers, http_redirect_port)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/PegaProx/pegaprox_multi_cluster.py", line 253, in <module>
    main(debug_mode=debug_mode)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^
gevent.exceptions.BlockingSwitchOutError: Impossible to call blocking function in the event loop callback
```
```
Traceback (most recent call last):
  File "/usr/lib/python3.13/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.13/runpy.py", line 88, in _run_code
    exec(code, run_globals)
  File "/root/.local/share/code-server/extensions/ms-python.debugpy-2026.6.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 71, in <module>
    cli.main()
  File "/root/.local/share/code-server/extensions/ms-python.debugpy-2026.6.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 542, in main
    run()
  File "/root/.local/share/code-server/extensions/ms-python.debugpy-2026.6.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 361, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/root/.local/share/code-server/extensions/ms-python.debugpy-2026.6.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 310, in run_path
    return _run_module_code(code, init_globals, run_name, pkg_name=pkg_name, script_name=fname)
  File "/root/.local/share/code-server/extensions/ms-python.debugpy-2026.6.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 127, in _run_module_code
    _run_code(code, mod_globals, init_globals, mod_name, mod_spec, pkg_name, script_name)
  File "/root/.local/share/code-server/extensions/ms-python.debugpy-2026.6.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 118, in _run_code
    exec(code, run_globals)
  File "pegaprox_multi_cluster.py", line 253, in <module>
    main(debug_mode=debug_mode)
  File "/opt/PegaProx/pegaprox/app.py", line 1200, in main
    _start_gevent_server(app, bind_host, port, ssl_context, domain, workers, http_redirect_port)
  File "/opt/PegaProx/pegaprox/app.py", line 1731, in _start_gevent_server
    http_server.serve_forever()
  File "/opt/PegaProx/venv/lib/python3.13/site-packages/gevent/baseserver.py", line 403, in serve_forever
    self._stop_event.wait()
  File "src/gevent/event.py", line 165, in gevent._gevent_cevent.Event.wait
  File "src/gevent/_abstract_linkable.py", line 529, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait
  File "src/gevent/_abstract_linkable.py", line 495, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 498, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 450, in gevent._gevent_c_abstract_linkable.AbstractLinkable._AbstractLinkable__wait_to_be_notified
  File "src/gevent/_abstract_linkable.py", line 459, in gevent._gevent_c_abstract_linkable.AbstractLinkable._switch_to_hub
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 65, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_gevent_c_greenlet_primitives.pxd", line 35, in gevent._gevent_c_greenlet_primitives._greenlet_switch
  File "/opt/PegaProx/pegaprox/app.py", line 1724, in signal_handler
    http_server.stop()
  File "/opt/PegaProx/venv/lib/python3.13/site-packages/gevent/baseserver.py", line 393, in stop
    self.pool.join(timeout=timeout)
  File "/opt/PegaProx/venv/lib/python3.13/site-packages/gevent/pool.py", line 430, in join
    result = self._empty_event.wait(timeout=timeout)
  File "src/gevent/event.py", line 165, in gevent._gevent_cevent.Event.wait
  File "src/gevent/_abstract_linkable.py", line 529, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait
  File "src/gevent/_abstract_linkable.py", line 495, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 498, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 450, in gevent._gevent_c_abstract_linkable.AbstractLinkable._AbstractLinkable__wait_to_be_notified
  File "src/gevent/_abstract_linkable.py", line 459, in gevent._gevent_c_abstract_linkable.AbstractLinkable._switch_to_hub
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 64, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 67, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch_out
  File "src/gevent/_greenlet_primitives.py", line 68, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch_out
gevent.exceptions.BlockingSwitchOutError: Impossible to call blocking function in the event loop callback
```

## Scope

- [x] This PR does **one thing**. Unrelated changes (a security fix + a feature + a refactor) belong
      in separate PRs so each can be reviewed and reverted on its own.

## How it was tested

<!-- Not "the CI is green" — what did YOU run, against which real cluster/setup, and what was the
     result? Paste the relevant output. A behaviour change to a core path needs real verification. -->
local and production 

## Checklist

- [x] There's a linked issue and the approach was discussed — or this is a small, obvious fix.
- [ ] The test suite passes locally, and I added/updated tests for this change.
- [x] It's scoped to the title and doesn't touch unrelated files.
- [x] If I used an AI assistant, **I have read, understood and tested every line myself** (this is
      not unreviewed generated output), **and I've named the assistant/model below** — we record it
      for licensing & compliance review.
      <!-- Which tool/model? e.g. Claude, GitHub Copilot, Gemini, GPT-4o, ... -->
      AI tool / model used: `OpenCode (Local LLM - Ornith-1.5-35B)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown handling so active connections can close cleanly without interrupting the event loop.
  * Ensured the SSH WebSocket service is stopped during application shutdown.
  * Added a shutdown timeout so long-lived connections cannot block server termination indefinitely.
  * Prevented expected connection and cancellation events during shutdown from producing unnecessary errors.
  * Ensured non-SSL connection failures continue to be reported appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent shutdown errors and orphaned console services on Ctrl+C

### What Changed
- Ctrl+C and termination signals now shut down the HTTP server without gevent traceback errors
- SSH console server processes are terminated when the main application exits
- Long-lived connections no longer block shutdown indefinitely; shutdown waits up to 10 seconds
- Expected connection cancellations during shutdown no longer appear as errors

### Impact
`✅ Clean Ctrl+C shutdowns`
`✅ No orphaned SSH console processes`
`✅ Shutdown completes within 10 seconds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
