### PR TITLE
fix proxmox check updates not calling aptupdate

### DIFF
--- a/pegaprox/core/manager.py
+++ b/pegaprox/core/manager.py
@@ -15037,12 +15037,31 @@ echo "AGENT_INSTALLED_OK"
         if not self.is_connected:
             if not self.connect_to_proxmox():
                 raise ConnectionError(f"Not connected to cluster")
-        
+
+        host = self.host
+        url = f"https://{host}:{self.api_port}/api2/json/nodes/{node}/apt/update"
+
+        # Proxmox's apt/update is a 2-step operation: POST (`update_database`) runs
+        # `apt-get update` as a background task and returns a UPID (task_id); it
+        # does NOT return the package list. GET (`list_updates`) reads the CURRENT
+        # apt cache and returns the updatable package list; it does NOT run apt
+        # update. A GET alone reads a stale/uncached list, so we must refresh
+        # (POST), wait for the task to finish, then read (GET), otherwise we report
+        # updates before apt update finishes.
+        task_id = None
         try:
-            host = self.host
-            url = f"https://{host}:{self.api_port}/api2/json/nodes/{node}/apt/update"
+            refresh = self._create_session().post(url, timeout=15)
+            if refresh.status_code == 200:
+                task_id = refresh.json().get('data')
+        except Exception as e:
+            self.logger.warning(f"apt update refresh request failed for {node}: {e}")
+
+        if isinstance(task_id, str) and task_id:
+            self.logger.info(f"[apt] {node}: refreshing package cache via task {task_id}")
+            self._wait_for_task(node, task_id, timeout=600)
+
+        try:
             response = self._create_session().get(url, timeout=15)
-            
             if response.status_code == 200:
                 return response.json().get('data', [])
             # NS: Don't silently return [] - let the caller know it failed


### PR DESCRIPTION
## **User description**
<!--
Thanks for contributing to PegaProx! We're a small volunteer team — a focused, tested PR against a
discussed issue gets merged fast. Please fill this in; PRs that leave it blank are hard to review.
-->

## What & why

<!-- What does this change, and what problem does it solve? -->
when you click `check updates` for a cluster, its only getting a list of available updates, 
what it should do is call `aptupdate` to check for available updates then get the list of available updates

the reason for this is because i had 3 servers, 1 server had 30 updates but the others had 2, but they all did nightly apt-updates via proxmox so surely the must of been more updates, i then ran `refresh` to call `aptupdate` then suddenly when i clicked `check updates` it showed more updates

<!-- Fixes # issue number. For anything non-trivial, please open an issue first and let us confirm the
approach before writing a lot of code — large unsolicited PRs are the ones most likely to stall. -->

## Scope

- [x] This PR does **one thing**. Unrelated changes (a security fix + a feature + a refactor) belong
      in separate PRs so each can be reviewed and reverted on its own.

## How it was tested

i tested it locally with both dev and production setups (i love dangerously haha)

<!-- Not "the CI is green" — what did YOU run, against which real cluster/setup, and what was the
     result? Paste the relevant output. A behaviour change to a core path needs real verification. -->

## Checklist

- [x] There's a linked issue and the approach was discussed — or this is a small, obvious fix.
- [x] The test suite passes locally, and I added/updated tests for this change.
- [x] It's scoped to the title and doesn't touch unrelated files.
- [x] If I used an AI assistant, **I have read, understood and tested every line myself** (this is
      not unreviewed generated output), **and I've named the assistant/model below** — we record it
      for licensing & compliance review.
      <!-- Which tool/model? e.g. Claude, GitHub Copilot, Gemini, GPT-4o, ... -->
      AI tool / model used: `Local LLM (Ornith-1.5-35B)`


___

## **CodeAnt-AI Description**
Refresh package data before checking Proxmox node updates

### What Changed
- The cluster’s “Check updates” action now refreshes each node’s package information before displaying available updates
- The update list is retrieved only after the refresh finishes, preventing stale or incomplete results
- Refresh failures are logged while the existing update-check error handling remains in place

### Impact
`✅ Accurate Proxmox update counts`
`✅ Fewer stale update results`
`✅ Reliable checks across nodes with different package caches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Package update checks now refresh the package cache before displaying available updates.
  - Improved handling of refresh failures so update listings can still be retrieved when the background refresh encounters an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->