### PR TITLE
fix(web): surface snapshot API errors in toasts

### DIFF
--- a/tests/test_ui_server_error_toasts.py
+++ b/tests/test_ui_server_error_toasts.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Regression guards for server-provided errors in snapshot toasts."""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+API_ERRORS = os.path.join(REPO_ROOT, 'web', 'src', 'api_errors.js')
+VM_MODALS = os.path.join(REPO_ROOT, 'web', 'src', 'vm_modals.js')
+BUILD_SCRIPT = os.path.join(REPO_ROOT, 'web', 'Dev', 'build.sh')
+
+
+def test_api_error_message_prefers_server_reason_and_keeps_fallback():
+    """The shipped JavaScript helper preserves the API error contract."""
+    node = shutil.which('node')
+    if not node:
+        pytest.skip('node is required to execute the frontend error helper')
+
+    script = r"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+const source = fs.readFileSync(process.argv[1], 'utf8');
+const sandbox = {};
+vm.runInNewContext(source + '\n;globalThis.__message = PegaProxApiErrors.message;', sandbox);
+(async () => {
+    const message = sandbox.__message;
+    if (await message(
+        {json: async () => ({error: 'Invalid snapshot name'})},
+        'Snapshot failed'
+    ) !== 'Invalid snapshot name') process.exit(1);
+    if (await message(
+        {json: async () => { throw new Error('not JSON'); }},
+        'Snapshot failed'
+    ) !== 'Snapshot failed') process.exit(2);
+    if (await message(null, 'Snapshot failed') !== 'Snapshot failed') process.exit(3);
+})().catch(() => process.exit(4));
+"""
+    result = subprocess.run(
+        [node, '-e', script, API_ERRORS], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_all_snapshot_mutations_use_localized_server_error_fallbacks():
+    source = open(VM_MODALS, encoding='utf-8').read()
+
+    assert source.count("PegaProxApiErrors.message(r, t('snapshotFailed'))") == 1
+    assert source.count("PegaProxApiErrors.message(r, t('deleteFailed'))") == 2
+    assert source.count("PegaProxApiErrors.message(r, t('rollbackFailed'))") == 2
+    assert "PegaProxApiErrors.message(r, 'Snapshot" not in source
+
+
+def test_all_snapshot_mutations_show_a_localized_network_error():
+    source = open(VM_MODALS, encoding='utf-8').read()
+
+    assert source.count("catch { addToast?.(t('snapshotFailed'), 'error'); }") == 1
+    assert source.count("catch { addToast?.(t('deleteFailed'), 'error'); }") == 2
+    assert source.count("catch { addToast?.(t('rollbackFailed'), 'error'); }") == 2
+
+
+def test_error_reader_is_loaded_before_snapshot_components():
+    source = open(BUILD_SCRIPT, encoding='utf-8').read()
+
+    assert source.index('api_errors.js') < source.index('vm_modals.js')

--- a/web/Dev/build.sh
+++ b/web/Dev/build.sh
@@ -45,6 +45,7 @@ echo ""
 # Source files in dependency order
 SRC_FILES=(
     constants.js
+    api_errors.js
     translations.js
     contexts.js
     auth.js

--- a/web/src/api_errors.js
+++ b/web/src/api_errors.js
@@ -1,0 +1,11 @@
+        // Keep API failures actionable without making every caller repeat the
+        // response parsing. A missing or non-JSON response still gets the
+        // caller's operation-specific fallback.
+        const PegaProxApiErrors = {
+            async message(response, fallback) {
+                if (!response) return fallback;
+                const body = await response.json().catch(() => null);
+                const error = typeof body?.error === 'string' ? body.error.trim() : '';
+                return error || fallback;
+            }
+        };

--- a/web/src/vm_modals.js
+++ b/web/src/vm_modals.js
@@ -1672,32 +1672,44 @@
                         body: JSON.stringify({ snapname: snapName, description: snapDesc, vmstate: snapRam ? 1 : 0 })
                     });
                     if (r?.ok) { addToast?.(t('snapshotCreated') || 'Snapshot created'); setShowCreateSnap(false); setSnapName(''); setSnapDesc(''); setSnapRam(false); fetchSnapshots(); }
-                    else addToast?.('Snapshot failed', 'error');
-                } catch(e) { addToast?.(e.message, 'error'); }
+                    else addToast?.(await PegaProxApiErrors.message(r, t('snapshotFailed')), 'error');
+                } catch { addToast?.(t('snapshotFailed'), 'error'); }
             };
 
             const handleDeleteSnap = async (name) => {
                 if (!confirm(`${t('deleteSnapshot') || 'Delete snapshot'} "${name}"?`)) return;
-                const r = await authFetch(`${API_URL}/clusters/${clusterId}/vms/${vm.node}/${vm.type}/${vm.vmid}/snapshots/${name}`, { method: 'DELETE' });
-                if (r?.ok) { addToast?.(t('snapshotDeleted') || 'Snapshot deleted'); fetchSnapshots(); }
+                try {
+                    const r = await authFetch(`${API_URL}/clusters/${clusterId}/vms/${vm.node}/${vm.type}/${vm.vmid}/snapshots/${name}`, { method: 'DELETE' });
+                    if (r?.ok) { addToast?.(t('snapshotDeleted') || 'Snapshot deleted'); fetchSnapshots(); }
+                    else addToast?.(await PegaProxApiErrors.message(r, t('deleteFailed')), 'error');
+                } catch { addToast?.(t('deleteFailed'), 'error'); }
             };
 
             const handleRollbackSnap = async (name) => {
                 if (!confirm(`${t('rollback') || 'Rollback'} "${name}"?`)) return;
-                const r = await authFetch(`${API_URL}/clusters/${clusterId}/vms/${vm.node}/${vm.type}/${vm.vmid}/snapshots/${name}/rollback`, { method: 'POST' });
-                if (r?.ok) addToast?.(t('rollbackStarted') || 'Rollback started');
+                try {
+                    const r = await authFetch(`${API_URL}/clusters/${clusterId}/vms/${vm.node}/${vm.type}/${vm.vmid}/snapshots/${name}/rollback`, { method: 'POST' });
+                    if (r?.ok) addToast?.(t('rollbackStarted') || 'Rollback started');
+                    else addToast?.(await PegaProxApiErrors.message(r, t('rollbackFailed')), 'error');
+                } catch { addToast?.(t('rollbackFailed'), 'error'); }
             };
 
             const handleDeleteEfficientSnap = async (id, name) => {
                 if (!confirm(`${t('deleteSnapshot') || 'Delete snapshot'} "${name}"?`)) return;
-                const r = await authFetch(`${API_URL}/clusters/${clusterId}/vms/${vm.node}/${vm.type}/${vm.vmid}/efficient-snapshots/${id}`, { method: 'DELETE' });
-                if (r?.ok) { addToast?.(t('snapshotDeleted') || 'Snapshot deleted'); fetchSnapshots(); }
+                try {
+                    const r = await authFetch(`${API_URL}/clusters/${clusterId}/vms/${vm.node}/${vm.type}/${vm.vmid}/efficient-snapshots/${id}`, { method: 'DELETE' });
+                    if (r?.ok) { addToast?.(t('snapshotDeleted') || 'Snapshot deleted'); fetchSnapshots(); }
+                    else addToast?.(await PegaProxApiErrors.message(r, t('deleteFailed')), 'error');
+                } catch { addToast?.(t('deleteFailed'), 'error'); }
             };
 
             const handleRollbackEfficientSnap = async (id, name) => {
                 if (!confirm(`${t('rollback') || 'Rollback'} "${name}"?`)) return;
-                const r = await authFetch(`${API_URL}/clusters/${clusterId}/vms/${vm.node}/${vm.type}/${vm.vmid}/efficient-snapshots/${id}/rollback`, { method: 'POST' });
-                if (r?.ok) addToast?.(t('rollbackStarted') || 'Rollback started');
+                try {
+                    const r = await authFetch(`${API_URL}/clusters/${clusterId}/vms/${vm.node}/${vm.type}/${vm.vmid}/efficient-snapshots/${id}/rollback`, { method: 'POST' });
+                    if (r?.ok) addToast?.(t('rollbackStarted') || 'Rollback started');
+                    else addToast?.(await PegaProxApiErrors.message(r, t('rollbackFailed')), 'error');
+                } catch { addToast?.(t('rollbackFailed'), 'error'); }
             };
 
             const formatBytes = b => {


### PR DESCRIPTION
## **User description**
## What & why

The five snapshot mutations in the Corporate VM detail view did not consistently
surface errors returned by the API. Snapshot creation replaced the server reason
with a generic English toast, while standard and efficient delete and rollback
failures were silent.

This change reads the JSON `error` for all five paths and keeps the existing
localized create, delete or rollback message when the response is missing or
malformed. Successful behavior remains unchanged.

Fixes #807

## Scope

- [x] This PR does **one thing**. Unrelated changes (a security fix + a feature + a refactor) belong
      in separate PRs so each can be reviewed and reverted on its own.

## How it was tested

- Reproduced the original behavior on PegaProx 1.1.1 with Chrome 152 as documented
  in #807: the API returned `{"error":"Invalid snapshot name"}`, but the Corporate
  snapshot form displayed only `Snapshot failed`.
- Ran `./web/Dev/build.sh`; the production bundle compiled successfully from all
  21 source files.
- Served the production bundle locally at `127.0.0.1` and exercised the Corporate
  VM → Snapshots → Create flow in Chromium with synthetic cluster data. A mocked
  HTTP 500 response containing `{"error":"Invalid snapshot name"}` produced a
  visible `Invalid snapshot name` error toast.
- Ran the focused regression suite: `4 passed in 0.05s`. It covers the server-error
  preference, malformed and missing response fallbacks, all five mutation paths,
  their localized fallback keys and bundle load order.
- Ran the complete test suite: `1405 passed, 51 warnings in 18.26s`.

## Checklist

- [x] There's a linked issue and the approach was discussed — or this is a small, obvious fix.
- [x] The test suite passes locally, and I added/updated tests for this change.
- [x] It's scoped to the title and doesn't touch unrelated files.
- [x] I used an AI assistant
      AI tool / model used: `OpenAI Codex (gpt-6-astra/gpt-5.6-sol)`


___

## **CodeAnt-AI Description**
Show useful errors when snapshot operations fail

### What Changed
- Snapshot creation, deletion, and rollback now display the error returned by the server when available
- Failed operations use localized create, delete, or rollback messages when the server response is missing, invalid, or unreachable
- Successful snapshot operations continue to behave as before

### Impact
`✅ Clearer snapshot failure messages`
`✅ Visible errors for failed deletes and rollbacks`
`✅ Localized fallback messages during network failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Snapshot create, delete, and rollback actions now display clear error notifications when server requests fail.
  - Server-provided error details are shown when available, with localized fallback messages used otherwise.
  - Network-related failures now use localized notifications instead of inconsistent or missing messages.
- **Tests**
  - Added regression coverage to verify consistent error handling and localized notifications across snapshot actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->